### PR TITLE
Update Gemma Technical Report link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains an inference implementation and examples, based on the
 
 ### Learn more about Gemma
 
--   The [Gemma technical report](https://ai.google.dev/gemma/technical-report)
+-   The [Gemma technical report](https://goo.gle/GemmaReport)
     details the models' capabilities.
 -   For tutorials, reference implementations in other ML frameworks, and more,
     visit https://ai.google.dev/gemma.


### PR DESCRIPTION
Former technical report link went to a 404. Updated with latest short link redirect from https://blog.google/technology/developers/gemma-open-models/