### PR TITLE
fix pyproject.toml:  The Poetry configuration is invalid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ authors = [
   "Surya Bhupatiraju <sbhupatiraju@google.com>",
   "Thomas Mesnard <mesnard@google.com>"
 ]
-python-version = "3.10"
 license = "Apache-2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
+python = ">=3.10"
 absl-py = "^2.1.0"
 sentencepiece = "^0.1.99"
 flax = "^0.7.5"


### PR DESCRIPTION
Running poetry install results in this error:
```
The Poetry configuration is invalid:
  - Additional properties are not allowed ('python-version' was unexpected)
```

With this change I can successfully install the package:
```
poetry install
Installing dependencies from lock file
No dependencies to install or update
Installing the current project: gemma (1.0.0)
```

Poetry version 1.7.1