### PR TITLE
Fix ReadMe Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To run the example sampling script, pass the paths to the weights directory and
 tokenizer:
 
 ```
-python examples/sampling.py -- \
+python examples/sampling.py \
   --path_checkpoint=/path/to/archive/contents/2b/ \
   --path_tokenizer=/path/to/archive/contents/tokenizer.model
 ```


### PR DESCRIPTION
## Summary
Fix ReadMe command.

Run this command from ReadMe
```
python examples/sampling.py -- \
--path_checkpoint=/Users/xu_hu/Developer/google/gemma-models/2b/2b/ \
--path_tokenizer=/Users/xu_hu/Developer/google/gemma-models/2b/tokenizer.model
```

But got error
```
FATAL Flags parsing error:
  flag --path_checkpoint=None: Flag --path_checkpoint must have a value other than None.
  flag --path_tokenizer=None: Flag --path_tokenizer must have a value other than None.
Pass --helpshort or --helpfull to see help on flags.
```

So, I remove `--`, then it does work.