### PR TITLE
Fix test when using pytest

### DIFF
--- a/gemma/transformer_test.py
+++ b/gemma/transformer_test.py
@@ -21,10 +21,14 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-jax.config.update('jax_numpy_rank_promotion', 'raise')
-
 
 class TransformerTest(parameterized.TestCase):
+  def setUp(self):
+    self.orig_config = jax.config.jax_numpy_rank_promotion
+    jax.config.update('jax_numpy_rank_promotion', 'raise')
+
+  def tearDown(self):
+    jax.config.update('jax_numpy_rank_promotion', self.orig_config)
 
   @parameterized.parameters(
       dict(


### PR DESCRIPTION
gemma/positional_embeddings_test.py rely on the default value of the config.

So we need to only change the config for that class Test. Not globally.