### PR TITLE
fix fine_tuning_tutorial.ipynb

### DIFF
--- a/colabs/fine_tuning_tutorial.ipynb
+++ b/colabs/fine_tuning_tutorial.ipynb
@@ -112,7 +112,7 @@
         "\n",
         "VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}\n",
         "weights_dir = kagglehub.model_download(f'google/gemma/Flax/{VARIANT}')\n",
-        "ckpt_path = os.path.join(weights_dir, variant)\n",
+        "ckpt_path = os.path.join(weights_dir, VARIANT)\n",
         "vocab_path = os.path.join(weights_dir, 'tokenizer.model')"
       ]
     },


### PR DESCRIPTION
Fixes trying to access a variable that was not defined (incorrect casing).