### PR TITLE
fixes linking of QAT file in the quantization_sampling.ipynb file

### DIFF
--- a/docs/quantization_aware_training.md
+++ b/docs/quantization_aware_training.md
@@ -1,0 +1,1 @@
+# QAT (Quantization Aware Traning)


### PR DESCRIPTION
Fixes linking of QAT file in the quantization_sampling.ipynb file
The quantization_sampling collab file has a link to the qualtization_aware_traning.md file but the markdown file is not present in the docs folder, so this PR adds a markdown file