### PR TITLE
fix: Docs link goes to wrong page

### DIFF
--- a/colabs/sampling.ipynb
+++ b/colabs/sampling.ipynb
@@ -344,7 +344,7 @@
         "\n",
         "Here's an example of predicting a single token, directly calling the model.\n",
         "\n",
-        "The model input expectes encoded tokens. For this, we first need to encode the prompt with our tokenizer. See our [tokenizer](https://gemma-llm.readthedocs.io/en/latest/multimodal.html) documentation for more information on using the tokenizer."
+        "The model input expectes encoded tokens. For this, we first need to encode the prompt with our tokenizer. See our [tokenizer](https://gemma-llm.readthedocs.io/en/latest/tokenizer.html) documentation for more information on using the tokenizer."
       ]
     },
     {


### PR DESCRIPTION
Tokenizer link goes to multimodal rather than tokenizer