### PR TITLE
Update README.md for tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ Our documentation contains various Colabs and tutorials, including:
 * [Sampling](https://gemma-llm.readthedocs.io/en/latest/colab_sampling.html)
 * [Multi-modal](https://gemma-llm.readthedocs.io/en/latest/colab_multimodal.html)
 * [Fine-tuning](https://gemma-llm.readthedocs.io/en/latest/colab_finetuning.html)
-* [LoRA](https://gemma-llm.readthedocs.io/en/latest/colab_lora_sampling.html)
-* ...
+* [Sharding](https://gemma-llm.readthedocs.io/en/latest/colab_sharding.html)
+* [Tokenizer](https://gemma-llm.readthedocs.io/en/latest/colab_tokenizer.html)
+* [LoRA (Sampling)](https://gemma-llm.readthedocs.io/en/latest/colab_lora_sampling.html)
+* [LoRA (Fine-tuning)](https://gemma-llm.readthedocs.io/en/latest/colab_lora_finetuning.html)
+* [Parameter Efficient Fine Tuning (PEFT)](https://gemma-llm.readthedocs.io/en/latest/peft.html)
+* [Checkpoints](https://gemma-llm.readthedocs.io/en/latest/checkpoints.html)
+* [Research](https://gemma-llm.readthedocs.io/en/latest/research.html)
 
 Additionally, our
 [examples/](https://github.com/google-deepmind/gemma/tree/main/examples) folder


### PR DESCRIPTION
Currently, the section which contains the list of various Colab tutorials and resources contains incomplete links, and ... as one of the bullet points. 

I have updated these links to include all the Colab tutorial links from the documentation page, and removed that ... which makes it easier to find specific resources, and links.