### PR TITLE
Fix gm.txt.chatsampler arguments for Colab instructions

### DIFF
--- a/colabs/sampling.ipynb
+++ b/colabs/sampling.ipynb
@@ -162,7 +162,6 @@
         "    model=model,\n",
         "    params=params,\n",
         "    multi_turn=True,\n",
-        "    print_stream=True,  # Print output as it is generated.\n",
         ")\n",
         "\n",
         "turn0 = sampler.chat('Share one methapore linking \"shadow\" and \"laughter\".')"


### PR DESCRIPTION
print stream is no longer a valid argument in gm.text.chatsampler, just removing it to make the colab notebook work flawlesslyst removing it to make the colab notebook work flawlessly