### PR TITLE
Docs: Fix broken Contributing link for ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ The 2B checkpoint and 24GB+ RAM on GPU are used for the 7B checkpoint.
 
 ### Contributing
 
-We welcome contributions! Please read our [Contributing Guidelines](./CONTRIBUTING.md) before submitting a pull request.
+We welcome contributions! Please read our [Contributing Guidelines](https://github.com/google-deepmind/gemma/blob/main/CONTRIBUTING.md) before submitting a pull request.
 
 *This is not an official Google product.*


### PR DESCRIPTION
This pull request updates the link to CONTRIBUTING.md in the documentation's README.md to use an absolute URL to the file on GitHub.
This ensures the Contributing link works both on GitHub and on the [webpage](https://gemma-llm.readthedocs.io/en/latest/) hosted through ReadTheDocs, improving the user experience for new contributors.