### PR TITLE
docs: convert raw sharding.py URL to markdown link

### DIFF
--- a/colabs/sharding.ipynb
+++ b/colabs/sharding.ipynb
@@ -433,7 +433,7 @@
         ")\n",
         "```\n",
         "\n",
-        "See a full example at: https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py"
+        "See a full example at: [sharding.py](https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py)"
       ]
     }
   ],


### PR DESCRIPTION
### Summary
This PR improves the readability of the sharding documentation by converting
a plain URL reference into a proper Markdown link.

### Changes
- Replaced:
  `See a full example at: https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py`
- With:
  `[sharding.py](https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py)`

### Impact
- Enhances documentation clarity and consistency
- Provides a cleaner reading experience for users

It fixes Issue #414 