### PR TITLE
fix: correct typo in FormatText docstring (detented → dedented) 

### DIFF
--- a/gemma/gm/data/_transforms.py
+++ b/gemma/gm/data/_transforms.py
@@ -42,7 +42,7 @@ class FormatText(kd.data.ElementWiseTransform):
 
   Attributes:
     template: The template containing the `{text}` placeholder. Note that the
-      template is detented (but not stripped).
+      template is dedented (but not stripped).
   """
 
   template: str


### PR DESCRIPTION
### Summary
This PR fixes a minor typo in the `FormatText` class docstring in `gemma/gm/data/_transforms.py`.  

**Incorrect:** `template is detented`  
**Correct:** `template is dedented`  

### Impact
- Improves clarity and correctness of the documentation.
- No functional changes; purely a documentation update.

It fixes Issue #415 