### PR TITLE
fix: correct comment typo in _transformer.py (specifiy → specify) 

### DIFF
--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -104,7 +104,7 @@ class Transformer(nn.Module):
   images: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):


### PR DESCRIPTION
### Summary
This PR fixes a small typo in a comment above the INFO field in `gemma/gm/nn/_transformer.py`.

**Incorrect:** `specifiy`  
**Correct:** `specify`

### Impact
- Documentation/comment update only.  
- No functional changes to the code.

It fixes #416 