### PR TITLE
Fix: align error message with validation logic in _add_custom_tokens

### DIFF
--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -268,7 +268,7 @@ class Tokenizer:
     for i, token in self.custom_tokens.items():
       if i < 0 or i > 98:
         raise ValueError(
-            f'Custom token id {i} for {token!r} is not in [1, 98].'
+            f'Custom token id {i} for {token!r} is not in [0, 98].'
         )
 
       # Update the piece


### PR DESCRIPTION
BUG FIX #421 
### Description

This PR corrects a minor inconsistency in the error message for custom token ID validation within the `_add_custom_tokens` method.

The validation logic correctly checks if an ID is within the range `[0, 98]`, but the `ValueError` message incorrectly stated the valid range was `[1, 98]`. This change updates the error message to match the actual validation logic, preventing potential confusion for developers.

This is a static text change in an error message. I have manually reviewed the code to ensure the new message `...is not in [0, 98].` accurately reflects the validation logic `if i < 0 or i > 98:`.

<img width="753" height="127" alt="image" src="https://github.com/user-attachments/assets/0e114859-fad7-4341-8659-1230b46e60ba" />
