### PR TITLE
Fix typos: accumulation, mismatch, formatting, externally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -256,7 +256,7 @@ single-line-if-stmt=yes
 max-module-lines=99999
 
 # String used as indentation unit.  The internal Google style guide mandates 2
-# spaces.  Google's externaly-published style guide says 4, consistent with
+# spaces.  Google's externally-published style guide says 4, consistent with
 # PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
 # projects (like TensorFlow).
 indent-string='  '

--- a/examples/lora.py
+++ b/examples/lora.py
@@ -85,7 +85,7 @@ def get_config():
               mask="batch.loss_mask",
           ),
       },
-      # TODO(epot): Add Gradient accumenlation.
+      # TODO(epot): Add Gradient accumulation.
       optimizer=kd.optim.partial_updates(
           optax.adafactor(learning_rate=0.005),
           # We only optimize the LoRA weights. The rest of the model is frozen.

--- a/gemma/gm/text/_prefill.py
+++ b/gemma/gm/text/_prefill.py
@@ -111,7 +111,7 @@ def prefill(
       {'params': params},
       tokens=prefill_input.tokens,
       images=prefill_input.images,
-      # Slice the cache to the prompt length, to avoid shape missmatch error.
+      # Slice the cache to the prompt length, to avoid shape mismatch error.
       cache=prefill_input.cache.cache,
       positions=prefill_input.positions,
       attention_mask=prefill_input.attention_mask,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ changelog = "https://github.com/google-deepmind/gemma/blob/main/CHANGELOG.md"
 # documentation = ""
 
 [project.optional-dependencies]
-# Development deps (unittest, linting, formating,...)
+# Development deps (unittest, linting, formatting,...)
 # Installed through `pip install -e .[dev]`
 dev = [
     "pytest",


### PR DESCRIPTION
# Fix typos 

This PR fixes the following typos:

- spelling of "accumulation" in a TODO comment in examples/lora.py (was "accumenlation").
- spelling of "mismatch" in a comment about cache slicing in gemma/gm/text/_prefill.py (was "missmatch").
- spelling of "formatting" in a comment about development dependencies in pyproject.toml (was "formating").
- spelling of "externally-published" in a comment about Google's style guide in .pylintrc (was "externaly-published").