### PR TITLE
Fix bug: Handle empty iterator in _print_stream function

### DIFF
--- a/gemma/gm/text/_chat_sampler.py
+++ b/gemma/gm/text/_chat_sampler.py
@@ -225,10 +225,16 @@ def _print_stream(
 ) -> _sampler.SamplerOutput:
   """Prints the streaming output."""
   text_tokens = []
+  last_state = None
   for state in out:
+    last_state = state  # Track the last state to avoid undefined variable
     text_tokens.append(state.text)
     if state.text == '<end_of_turn>':  # Last token is not printed.
       continue
     print(state.text, end='', flush=True)
-  out = dataclasses.replace(state, text=''.join(text_tokens))  # pylint: disable=undefined-variable,undefined-loop-variable
+  if last_state is None:
+    raise ValueError(
+        'Empty iterator passed to _print_stream. No states were yielded.'
+    )
+  out = dataclasses.replace(last_state, text=''.join(text_tokens))
   return out


### PR DESCRIPTION
The _print_stream function had a bug where if the iterator was empty (no states were yielded), the variable 'state' would be undefined when accessed outside the loop, causing a NameError.

Changes:
- Track the last state during iteration in a separate variable (last_state)
- Add explicit check for empty iterator case and raise ValueError with clear message
- Preserve existing code structure with assignment to 'out' variable before return

This fixes a potential runtime error that could occur in edge cases where the streaming iterator yields no states, such as early termination before any states are produced.

Location: gemma/gm/text/_chat_sampler.py lines 223-240