### PR TITLE
Fix typo in comment in _transformer.py (credit: @akshay0611)

### DIFF
--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -106,7 +106,7 @@ class Transformer(nn.Module):
   attention_mask: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):


### PR DESCRIPTION
This PR fixes a small typo in a comment inside
gemma/gm/nn/_transformer.py.

Original issue reported by @akshay0611 in Issue https://github.com/google-deepmind/gemma/issues/420 

Change included:

Corrected "specifiy" → "specify"
This PR does not modify any functional code and is limited to a comment fix.