### PR TITLE
docs: add non-English evaluation results for Gemma 3n

### DIFF
--- a/tests/evaluation/non_english_results.md
+++ b/tests/evaluation/non_english_results.md
@@ -1,0 +1,27 @@
+# Non-English Evaluation Results for Gemma 3n (E2B / E4B)
+
+## Spanish
+
+**Prompt:**
+Hola, ¿cómo estás?
+
+**Observed Behavior:**
+The model struggles to maintain conversational consistency. Some responses are partially correct, but grammar and context degrade quickly.
+
+---
+
+## Russian
+
+**Prompt:**
+Привет, как дела?
+
+**Observed Behavior:**
+The model shows noticeable grammatical errors and sometimes produces repetitive or irrelevant output.
+
+---
+
+## Notes
+
+- No model weights or parameters were modified.
+- These results are observational and meant to highlight current multilingual limitations.
+- Intended to support Issue #460 and guide future improvements.


### PR DESCRIPTION
## Description

This PR adds documented evaluation results showing performance degradation of Gemma 3n E2B/E4B models in non-English languages.

The goal is to provide reproducible, human readable evidence to support multilingual quality improvements in future releases.

No model weights or inference code were modified.

## Related Issue
Resolves #460 
