### PR TITLE
docs: fix subject-verb agreement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Our documentation contains various Colabs and tutorials, including:
 
 Additionally, our
 [examples/](https://github.com/google-deepmind/gemma/tree/main/examples) folder
-contain additional scripts to fine-tune and sample with Gemma.
+contains additional scripts to fine-tune and sample with Gemma.
 
 ### Learn more about Gemma
 


### PR DESCRIPTION
Fixes #485

Fixes a subject-verb agreement error in README.md. The sentence "Additionally, our examples/ folder contain additional scripts" has been corrected to "contains" since "folder" is singular.