### PR TITLE
Fix: Handle empty prompt arrays in make_seq2seq_fields (#483)

### DIFF
--- a/gemma/gm/data/_functional.py
+++ b/gemma/gm/data/_functional.py
@@ -138,9 +138,18 @@ def make_seq2seq_fields(
   sequence = np.concatenate([prompt, response])
 
   # Create the loss mask.
+  if len(prompt) > 0:
+    prompt_mask = np.zeros((len(prompt) - 1,), dtype=np.bool_)
+    response_mask = np.ones((len(response),), dtype=np.bool_)
+  else:
+    # If no prompt, all targets come from response (shifted by 1)
+    prompt_mask = np.zeros((0,), dtype=np.bool_)
+    # Ensure non-negative shape if response is also empty or length 1
+    response_mask = np.ones((max(0, len(response) - 1),), dtype=np.bool_)
+
   target_mask = np.concatenate([
-      np.zeros((len(prompt) - 1,), dtype=np.bool_),
-      np.ones((len(response),), dtype=np.bool_),
+      prompt_mask,
+      response_mask,
   ])
 
   return Seq2SeqFields(


### PR DESCRIPTION
Resolves #483. This PR fixes a crash in make_seq2seq_fields when an empty prompt array is provided. The previous logic attempted to create a target mask with negative dimensions (len(prompt) - 1) when prompt was empty. The fix adds conditional logic to generate a correct mask (based on response length) if the prompt is empty.