### PR TITLE
Fix: Correct typo in _transformer.py

### DIFF
--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -106,7 +106,7 @@ class Transformer(nn.Module):
   attention_mask: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):


### PR DESCRIPTION
Resolves #416.\n\nCorrects the typo \specifiy\ to \specify\ in the doc comment of \gemma/gm/nn/_transformer.py\.