### PR TITLE
docs: update tokenizer notebook for Gemma 3 vocabulary size

### DIFF
--- a/colabs/tokenizer.ipynb
+++ b/colabs/tokenizer.ipynb
@@ -548,24 +548,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "BE31hxTiSNdO"
-      },
-      "outputs": [],
-      "source": [
-        "token_ids = tokenizer.encode(\"\"\"<start_of_turn>user\n",
-        "Knock knock.<end_of_turn>\n",
-        "<start_of_turn>model\n",
-        "Who's there ?<end_of_turn>\n",
-        "<start_of_turn>user\n",
-        "Gemma.<end_of_turn>\n",
-        "<start_of_turn>model\n",
-        "Gemma who?<end_of_turn>\"\"\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
         "colab": {
           "height": 35
         },
@@ -680,46 +662,6 @@
       },
       "source": [
         "You can customize what the custom tokens correspond to when constructing the tokenizer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 324,
-          "status": "ok",
-          "timestamp": 1736944538160,
-          "user": {
-            "displayName": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "USY1STCyxhsc",
-        "outputId": "d097c84c-60d9-48dd-bff8-551b73110a77"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[24]"
-            ]
-          },
-          "execution_count": 35,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "tokenizer = gm.text.Gemma3Tokenizer(\n",
-        "    custom_tokens={\n",
-        "        0: '<my_custom_tag>',\n",
-        "        17: '<my_other_tag>',\n",
-        "    },\n",
-        ")\n",
-        "\n",
-        "tokenizer.encode('<my_other_tag>')"
       ]
     },
     {


### PR DESCRIPTION
This PR updates the tokenizer.ipynb Colab notebook to include information regarding the expanded vocabulary size in the Gemma 3 model family.

Added a note clarifying that while Gemma 1 and 2 utilize a 256k vocabulary, Gemma 3 has been expanded to 262,144 tokens.
