### PR TITLE
fix(data): add input validation for empty prompt/response in make_seq2seq_fields

### DIFF
--- a/gemma/gm/data/_functional.py
+++ b/gemma/gm/data/_functional.py
@@ -133,7 +133,22 @@ def make_seq2seq_fields(
 
   Returns:
     The input, target and mask, all of length `prompt_len + response_len - 1`.
+
+  Raises:
+    ValueError: If prompt or response is empty.
   """
+  # Validate inputs
+  if len(prompt) == 0:
+    raise ValueError(
+        "Cannot create seq2seq fields with empty prompt. "
+        "Prompt must contain at least one token."
+    )
+  if len(response) == 0:
+    raise ValueError(
+        "Cannot create seq2seq fields with empty response. "
+        "Response must contain at least one token."
+    )
+
   # Concatenate the prompt and response tokens.
   sequence = np.concatenate([prompt, response])
 


### PR DESCRIPTION
## Summary

This PR adds input validation to the make_seq2seq_fields function to handle empty prompt/response arrays gracefully.

## Problem

When an empty prompt or response array is passed to make_seq2seq_fields, the function crashes with confusing numpy errors (negative array dimensions) instead of providing a clear error message.

Fixes #483

## Solution

Added validation at the start of the function that:
- Checks if prompt is empty and raises ValueError with clear message
- Checks if esponse is empty and raises ValueError with clear message

## Changes

**File**: gemma/gm/data/_functional.py
- Added input validation for empty arrays
- Updated docstring to document the new Raises section

## Testing

- Syntax validation passed
- The fix provides clear error messages instead of cryptic numpy errors