### PR TITLE
docs: convert raw sharding.py URL to markdown link

### DIFF
--- a/colabs/sharding.ipynb
+++ b/colabs/sharding.ipynb
@@ -433,7 +433,7 @@
         ")\n",
         "```\n",
         "\n",
-        "See a full example at: https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py"
+        "See a full example at: [sharding.py](https://github.com/google-deepmind/gemma/tree/main/examples/sharding.py)"
       ]
     }
   ],


### PR DESCRIPTION
This PR fixes an incorrect Markdown link in `colabs/sharding.ipynb`.

The reference to `sharding.py` was previously rendered as plain text,
which made it non-clickable. This change converts it into a proper
Markdown link so users can easily navigate to the example file.

No functional or behavioral changes are included.
