### PR TITLE
Fix SimulateQuantizedEinsum to use einsum_str instead of module name …

### DIFF
--- a/gemma/peft/_quantization.py
+++ b/gemma/peft/_quantization.py
@@ -189,7 +189,7 @@ class SimulateQuantizedEinsum(nn.Module):
         kernel,
         self.method,
         axis_to_reduce=get_axis_to_reduce_from_einsum_str(
-            einsum_str=self.wrapped.name
+            einsum_str=einsum_str
         ),
     )
 


### PR DESCRIPTION
…for pattern-specific quantization

- Changed line 192 in gemma/peft/_quantization.py from einsum_str=self.wrapped.name to einsum_str=einsum_str
- This enables pattern-specific quantization axis selection logic in get_axis_to_reduce_from_einsum_str()
- Previously, module names like 'attention_proj' were passed, always returning None and forcing fallback to generic per-channel scaling
- Now actual einsum equations like 'BTD,NDH->BTNH' are passed, enabling optimal pattern-specific scaling
- Improves quantization accuracy for all einsum operations in quantization-aware training workflows