### PR TITLE
feat(data): Add 'axis' support to gm.data.pad

### DIFF
--- a/gemma/gm/data/_functional_test.py
+++ b/gemma/gm/data/_functional_test.py
@@ -63,3 +63,17 @@ def test_seq2seq():
   np.testing.assert_array_equal(out.input, expected_output["input"])
   np.testing.assert_array_equal(out.target, expected_output["target"])
   np.testing.assert_array_equal(out.target_mask, expected_output["target_mask"])
+
+
+def test_pad_axis():
+  arr = np.ones((2, 2))
+  # Pad axis 0 (rows) to 4
+  out = gm.data.pad(arr, max_length=4, axis=0)
+  np.testing.assert_array_equal(out.shape, (4, 2))
+  # Check content: first 2 rows are 1s, last 2 are 0s/fill_value
+  np.testing.assert_array_equal(out[:2], np.ones((2, 2)))
+  np.testing.assert_array_equal(out[2:], np.zeros((2, 2)))
+
+  # Test axis -2 (same as 0 for 2D)
+  out_neg = gm.data.pad(arr, max_length=4, axis=-2)
+  np.testing.assert_array_equal(out, out_neg)


### PR DESCRIPTION
**Title:** `feat(data): Add 'axis' support to gm.data.pad`

## Description
This PR implements the missing `axis` argument in `gm.data.pad`, addressing the TODO left in `gemma/gm/data/_functional.py`.

Previously, `gm.data.pad` raised a `NotImplementedError` if `axis != -1`. This change enables padding along arbitrary axes, which is essential for handling multi-dimensional data pipelines in JAX (e.g., padding batch dimensions or specific feature dimensions).

## Changes
*   **gemma/gm/data/_functional.py**: 
    *   Removed `NotImplementedError` guard.
    *   Implemented `pad_width` construction logic to target the specified `axis`.
*   **gemma/gm/data/_functional_test.py**:
    *   Added `test_pad_axis` regression test to verify padding on `axis=0` and `axis=-2`.

## Verification
*   Added new test case: `test_pad_axis` (Passed).
*   Ran existing tests: `test_pad`, `test_seq2seq` (Passed).

## Related Issue
Resolves `TODO(epot): Could add an axis= kwarg to support multi-dimensional arrays.`
