### PR TITLE
docs(ckpts): Clarify 'quantize' behavior in load_params

### DIFF
--- a/gemma/gm/ckpts/_checkpoint.py
+++ b/gemma/gm/ckpts/_checkpoint.py
@@ -219,7 +219,8 @@ def load_params(
     sharding: If provided, the params will be restored with this sharding. This
       is mutually exclusive with `params`.
     quantize: If `True`, the params will be mapped to enable quantization aware
-      training.
+      training (QAT). Note: This does NOT quantize the weights to int8/int4;
+      it only converts the structure. Actual quantization occurs during training.
 
   Returns:
     The restored params.


### PR DESCRIPTION
**Title:** `docs(ckpts): Clarify 'quantize' behavior in load_params`

## Description
This PR addresses the TODO at line 277 regarding the `quantize` argument in `_checkpoint.py`.

Currently, the `quantize=True` argument in `load_params` does not perform actual weight quantization (e.g., to int8), but rather restructures the parameters for Quantization Aware Training (QAT). This can be misleading for users expecting immediate weight compression.

This change updates the docstring to explicitly state that `quantize=True` only enables the QAT structure, improving API clarity and developer experience.

## Changes
*   **gemma/gm/ckpts/_checkpoint.py**: Updated `load_params` docstring to clarify that actual quantization happens during training, not loading.

## Related Issue
Refers to: `# TODO(epot): Better API. Currently this do not quantize the weights...`
