### PR TITLE
tests: relax RMSNorm/RoPE tolerances

### DIFF
--- a/gemma/gm/math/_positional_embeddings_test.py
+++ b/gemma/gm/math/_positional_embeddings_test.py
@@ -65,4 +65,9 @@ def test_rope_positional_embeddings(
       base_frequency=max_wavelength,
       rope_proportion=rope_proportion,
   )
-  np.testing.assert_array_almost_equal(outputs, jnp.array(expected))
+  np.testing.assert_allclose(
+      outputs,
+      jnp.array(expected),
+      rtol=1e-5,
+      atol=1e-5,
+  )

--- a/gemma/gm/nn/_layers_test.py
+++ b/gemma/gm/nn/_layers_test.py
@@ -47,4 +47,9 @@ def test_rmsnorm(x, expected):
   rmsnorm = gm.nn.RMSNorm()
   params = rmsnorm.init(jax.random.PRNGKey(0), x)
   output = rmsnorm.apply(params, x)
-  np.testing.assert_array_equal(output, jnp.array([expected]))
+  np.testing.assert_allclose(
+      output,
+      jnp.array([expected]),
+      rtol=1e-5,
+      atol=1e-5,
+  )

--- a/gemma/gm/nn/gemma3n/_layers_test.py
+++ b/gemma/gm/nn/gemma3n/_layers_test.py
@@ -51,7 +51,12 @@ def test_rmsnorm(x, expected):
   rmsnorm = _layers.RMSNorm()
   params = rmsnorm.init(jax.random.PRNGKey(0), x)
   output = rmsnorm.apply(params, x)
-  np.testing.assert_array_equal(output, jnp.array([expected]))
+  np.testing.assert_allclose(
+      output,
+      jnp.array([expected]),
+      rtol=1e-5,
+      atol=1e-5,
+  )
 
 
 @pytest.mark.parametrize(
@@ -71,4 +76,9 @@ def test_rmsnorm_with_scale(x, expected, with_scale, scale_init):
   rmsnorm = _layers.RMSNorm(with_scale=with_scale, scale_init=scale_init)
   params = rmsnorm.init(jax.random.PRNGKey(0), x)
   output = rmsnorm.apply(params, x)
-  np.testing.assert_array_equal(output, jnp.array([expected]))
+  np.testing.assert_allclose(
+      output,
+      jnp.array([expected]),
+      rtol=1e-5,
+      atol=1e-5,
+  )


### PR DESCRIPTION
Fixes #32
Fixes #33

What changed:
- Use assert_allclose with rtol/atol for RMSNorm and RoPE tests to avoid GPU float jitter.

Test:
- pytest gemma/gm/nn/_layers_test.py gemma/gm/nn/gemma3n/_layers_test.py gemma/gm/math/_positional_embeddings_test.py (AWS eu-central-2, Amazon Linux 2023)