### PR TITLE
DOC: Add more specific GPU examples to System Requirements in README.md #395

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ To download the model weights. See
 
 ### System Requirements
 
-Gemma can run on a CPU, GPU and TPU. For GPU, we recommend 8GB+ RAM on GPU for
-The 2B checkpoint and 24GB+ RAM on GPU are used for the 7B checkpoint.
+Gemma can run on a CPU, GPU and TPU. For GPU, we recommend 8GB+ VRAM for the 2B
+checkpoint and 24GB+ VRAM for the 7B checkpoint. For reference, GPUs with 8GB+
+VRAM include models like the NVIDIA RTX 3060, while models with 24GB+ VRAM
+include the NVIDIA RTX 4090 and AMD Radeon RX 7900 XTX.
 
 ### Contributing
 


### PR DESCRIPTION
Summary
Add concrete GPU examples for the 8GB+ and 24GB+ VRAM recommendations in the System Requirements section.
Improve readability by using “VRAM” terminology consistently.
Rationale
New users can quickly gauge if their hardware meets the model requirements without looking up GPU memory specs elsewhere.
Changes
Update README.md System Requirements text to include example GPUs (RTX 3060 for 8GB+, RTX 4090 and RX 7900 XTX for 24GB+).
Testing
Not applicable (documentation-only change).