### PR TITLE
docs: add WSL2 installation recommendations for Windows users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ poetry.lock
 # Ignore generated docs
 docs/_build
 docs/api
+
+#Virtual Environment
+.venv/

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ report issues and feedback in
 
 ### Installation
 
-1.  Install JAX for CPU, GPU or TPU. Follow the instructions on
-    [the JAX website](https://jax.readthedocs.io/en/latest/installation.html).
-1.  Run
+**Note for Windows Users:** Native Windows installations are not officially supported and frequently encounter JAX compatibility issues. We **strongly recommend** using [WSL2 (Ubuntu 24.04)](https://learn.microsoft.com/en-us/windows/wsl/install) with **Python 3.12**. Avoid Python 3.14+ as stable JAX wheels are not yet available for these versions.
 
+1.  **Install JAX:** Follow the platform-specific instructions (CPU, GPU, or TPU) on [the JAX website](https://jax.readthedocs.io/en/latest/installation.html).
+2.  **Install Gemma:**
     ```sh
     pip install gemma
     ```


### PR DESCRIPTION
### Summary
This PR updates the README to include specific installation recommendations for Windows users.

### Why is this change necessary?
Native Windows installations frequently encounter compatibility issues with JAX and type annotations, especially with newer Python versions (3.14+). Recommending WSL2 (Ubuntu 24.04) and Python 3.12 provides a stable, officially supported-style path for Windows-based developers to use Gemma.

### Changes
- Added a "Note for Windows Users" section before the main installation steps.
- Specified WSL2 and Python 3.12 as the recommended environment.
- Warned against using Python 3.14+ due to a lack of stable JAX wheels.