### PR TITLE
Add sandbox restrictions to FileExplorer to prevent arbitrary file access

### DIFF
--- a/gemma/gm/tools/_file_explorer.py
+++ b/gemma/gm/tools/_file_explorer.py
@@ -16,28 +16,124 @@
 
 from __future__ import annotations
 
+import os
 from etils import epath
 from etils import epy
 from gemma.gm.tools import _tools
 
 
 class FileExplorer(_tools.Tool):
-  """File explorer tool (read-only)."""
+  """File explorer tool (read-only, sandboxed).
 
-  DESCRIPTION = 'File explorer tool.'
+  This tool restricts file access to a sandbox directory to prevent arbitrary
+  file reads. By default, it only allows access to the current working directory
+  or a specified sandbox root.
+  """
+
+  DESCRIPTION = 'File explorer tool (read-only, sandboxed).'
   EXAMPLE = _tools.Example(
-      query="What's the content of /tmp/foo.txt?",
-      thought='I need to `cat /tmp/foo.txt`.',
-      tool_kwargs={'method': 'cat', 'path': '/tmp/foo.txt'},
+      query="What's the content of ./data/foo.txt?",
+      thought='I need to `cat ./data/foo.txt`.',
+      tool_kwargs={'method': 'cat', 'path': './data/foo.txt'},
       tool_kwargs_doc={'method': 'ONEOF(cat, ls)', 'path': '<PATH>'},
       result='...',
       answer='Here is the content of the file: ...',
   )
   KEYWORDS = ('file', 'directory', 'folder')
 
+  def __init__(self, sandbox_root: str | epath.Path | None = None):
+    """Initialize FileExplorer with optional sandbox restriction.
+
+    Args:
+      sandbox_root: Root directory for file access. If None, defaults to current
+        working directory. All file operations are restricted to this directory
+        and its subdirectories.
+    """
+    super().__init__()
+    if sandbox_root is None:
+      # Default to current working directory as sandbox
+      sandbox_root = os.getcwd()
+    self._sandbox_root = epath.Path(sandbox_root).resolve()
+    # Ensure sandbox exists
+    if not self._sandbox_root.exists():
+      raise ValueError(f'Sandbox root does not exist: {self._sandbox_root}')
+
+  def _validate_path(self, path: epath.Path) -> tuple[bool, str]:
+    """Validates that the path is within the sandbox and not sensitive.
+
+    Returns:
+      Tuple of (is_valid, error_message). If is_valid is True, error_message is empty.
+    """
+    # Resolve to absolute path
+    resolved_path = path.resolve()
+
+    # Block access to sensitive system paths
+    sensitive_prefixes = [
+        '/etc',
+        '/usr',
+        '/bin',
+        '/sbin',
+        '/var',
+        '/sys',
+        '/proc',
+        '/dev',
+        '/root',
+    ]
+    # Also block home directory sensitive paths
+    home = epath.Path(os.path.expanduser("~"))
+    sensitive_home_paths = [
+        home / '.ssh',
+        home / '.bashrc',
+        home / '.bash_history',
+        home / '.zshrc',
+        home / '.gitconfig',
+        home / '.env',
+    ]
+
+    path_str = str(resolved_path)
+    for prefix in sensitive_prefixes:
+      if path_str.startswith(prefix):
+        return False, f'Access denied: Path is in a restricted system directory ({prefix})'
+
+    for sensitive_path in sensitive_home_paths:
+      # Check if path equals or is a subpath of sensitive path
+      try:
+        resolved_path.relative_to(sensitive_path)
+        return False, f'Access denied: Path is restricted for security ({sensitive_path})'
+      except ValueError:
+        # Path is not relative to sensitive_path, continue checking
+        if resolved_path == sensitive_path:
+          return False, f'Access denied: Path is restricted for security ({sensitive_path})'
+
+    # Ensure path is within sandbox
+    try:
+      resolved_path.relative_to(self._sandbox_root)
+    except ValueError:
+      return False, (
+          f'Access denied: Path is outside sandbox. '
+          f'Sandbox root: {self._sandbox_root}, '
+          f'Requested path: {resolved_path}'
+      )
+
+    return True, ''
+
   def call(self, method: str, path: str) -> str:  # pytype: disable=signature-mismatch
-    """Calculates the expression."""
+    """Reads file or lists directory (sandboxed).
+
+    Args:
+      method: Either 'cat' to read a file or 'ls' to list directory contents.
+      path: Path to file or directory. Must be within the sandbox root.
+
+    Returns:
+      File contents or directory listing, or error message if access is denied.
+    """
     path = epath.Path(path)
+
+    # Validate path before any operation
+    is_valid, error_msg = self._validate_path(path)
+    if not is_valid:
+      return error_msg
+
     if method == 'cat':
       try:
         return path.read_text()


### PR DESCRIPTION
Fixes #517
#### Summary
This PR fixes a security vulnerability in `FileExplorer` by adding path restrictions and validation. The tool previously allowed unrestricted access to any file the process could read, including sensitive system files, SSH keys, and user credentials.

#### What Changed
- **Added sandbox restriction**: `FileExplorer` now restricts file access to a configurable sandbox directory (defaults to current working directory)
- **Blocked sensitive system paths**: Explicitly blocks access to `/etc`, `/usr`, `/bin`, `/sbin`, `/var`, `/sys`, `/proc`, `/dev`, `/root`
- **Blocked sensitive home paths**: Blocks access to `~/.ssh`, `~/.bashrc`, `~/.bash_history`, `~/.zshrc`, `~/.gitconfig`, `~/.env`
- **Path validation**: All paths are validated before any file operation
- **Clear error messages**: Returns descriptive error messages when access is denied

#### Security Impact
**Before**: FileExplorer could read any file accessible to the process, allowing:
- Credential theft (SSH keys, API tokens, passwords)
- System information disclosure (`/etc/passwd`, config files)
- Privacy violations (user data, personal files)

**After**: FileExplorer is restricted to a sandbox directory and blocks access to sensitive paths, preventing arbitrary file reads.

#### Implementation Details
- Added `__init__()` method with optional `sandbox_root` parameter
- Added `_validate_path()` method that checks:
  1. Path is within the sandbox root
  2. Path is not in a restricted system directory
  3. Path is not a sensitive home directory file
- Updated `call()` method to validate paths before file operations
- Updated documentation and examples to reflect sandboxing

#### Testing
The fix has been verified with a demo script that shows:
- Attempts to access paths outside sandbox → Access denied
- Attempts to access sensitive home files → Access denied  
- Attempts to access system files → Access denied

All attack scenarios are now properly blocked.

<img width="1464" height="893" alt="Screenshot 2026-01-26 at 1 40 26 AM" src="https://github.com/user-attachments/assets/71f79e8b-e0fd-4aab-b573-3f65c9717258" />



