### PR TITLE
docs: Add image loading code to multimodal example

### DIFF
--- a/gemma/gm/evals/_sample.py
+++ b/gemma/gm/evals/_sample.py
@@ -91,7 +91,7 @@ class SamplerEvaluator(kd.evals.EvaluatorBase):
     # TODO(epot): Better sharding, a few options:
     #  1. Allow to customize the sharding to process examples
     #  2. Or auto-detect the sharding to set to `FIRST_DIM` when possible.
-    #  3. Re-use sharding from `trainer.sharding.ds`
+    #  3. Re-use sharding from `trainer.sharding.batch`
     if self.ds.batch_size is None:
       sharding = kd.sharding.REPLICATED
     else:


### PR DESCRIPTION
## Description
Fixes the multimodal example in README by adding missing image loading code. 

## Problem
The current example uses undefined variables `image1` and `image2`, causing a `NameError` when users try to run the code. 

## Solution
- Added `from PIL import Image` and `import numpy as np` imports
- Added example code showing how to load images and convert to NumPy arrays
- Matches the format expected by Gemma's ChatSampler (NumPy arrays with uint8 dtype)

## Testing
- Verified against official docs: https://gemma-llm.readthedocs.io/en/latest/colab_multimodal.html
- Confirmed NumPy array format is compatible with ChatSampler

## Impact
Makes the example copy-pasteable and executable for new users.
