### PR TITLE
Fix make_seq2seq_fields crash on empty prompt

### DIFF
--- a/gemma/gm/data/_functional.py
+++ b/gemma/gm/data/_functional.py
@@ -135,6 +135,8 @@ def make_seq2seq_fields(
     The input, target and mask, all of length `prompt_len + response_len - 1`.
   """
   # Concatenate the prompt and response tokens.
+  if len(prompt) == 0 :
+    raise ValueError("prompt must be a non-empty sequence of token ids")
   sequence = np.concatenate([prompt, response])
 
   # Create the loss mask.


### PR DESCRIPTION
### Summary
Adds explicit input validation to `make_seq2seq_fields` to fail fast when an
empty prompt is provided, avoiding a cryptic NumPy error.

### Rationale
Currently, passing an empty prompt results in
`ValueError: negative dimensions are not allowed`, which originates from NumPy and is difficult for users to diagnose. This change provides a clear,
user-facing error message instead.

Tested locally by reproducing the empty-prompt case via make_seq2seq_fields and AddSeq2SeqFields.

Closes #483