### PR TITLE
fix: add missing f-string prefix and fix 'voab' typo

### DIFF
--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -548,7 +548,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
+        f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
         ' map to single token ids in the vocab.'
     )
   (token_id,) = token_id

--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -282,7 +282,7 @@ class Tokenizer:
       if piece.piece != f'<unused{i}>':
         raise AssertionError(
             f'Expected custom token id {i} for {token!r} to be `<unused{i}>`,'
-            f' but was {piece.piece}. This indicates the voab file'
+            f' but was {piece.piece}. This indicates the vocab file'
             " isn't as expected."
         )
       piece.piece = token


### PR DESCRIPTION
## Summary

Two small bug fixes in error messages:

1. **`gemma/gm/text/_sampler.py`** (`_normalize_token()`): The error message raised when a token maps to multiple IDs was missing the `f` prefix on the f-string, causing the literal text `{token!r}` to be displayed instead of the actual token value.

2. **`gemma/gm/text/_tokenizer.py`** (`_add_custom_tokens()`): Fixed typo `'voab'` → `'vocab'` in the assertion error message.

## Test plan

- [x] Existing tests pass (`pytest -vv gemma/gm/text/_sampler_test.py gemma/gm/text/_tokenizer_test.py` — 3/3 pass)
- [x] Full test suite passes (97/98 pass; 1 failure is `grain`-related, Windows-expected)
- [x] No formatting changes beyond the two fixed lines