### PR TITLE
feat: add min-p sampling method

### DIFF
--- a/gemma/gm/text/__init__.py
+++ b/gemma/gm/text/__init__.py
@@ -33,12 +33,12 @@ with _epy.lazy_api_imports(globals()):
   from gemma.gm.text._tool_sampler import ToolSampler
 
   # Sampling methods
-  # TODO(mblondel): Add nucleus sampling
   from gemma.gm.text._sampling import SamplingMethod
   from gemma.gm.text._sampling import Greedy
   from gemma.gm.text._sampling import RandomSampling
   from gemma.gm.text._sampling import TopkSampling
   from gemma.gm.text._sampling import TopPSampling
+  from gemma.gm.text._sampling import MinPSampling
 
   # Other utils
   # from gemma.gm.text import _template as template

--- a/gemma/gm/text/_sampling_test.py
+++ b/gemma/gm/text/_sampling_test.py
@@ -79,3 +79,39 @@ def test_top1_sampling_matches_greedy_sampling():
   tokens_top1 = top1_sampling.get_next_tokens(logits, rng)
   np.testing.assert_array_equal(tokens_greedy, tokens_top1)
 
+
+def test_minp_sampling():
+  sampling = gm.text.MinPSampling(min_p=0.1)
+  rng = jax.random.PRNGKey(0)
+  batch_size = 2
+  vocab_size = 5
+  logits = jax.random.normal(rng, shape=(batch_size, vocab_size))
+  tokens = sampling.get_next_tokens(logits, rng)
+  assert tokens.shape == (batch_size,)
+
+
+def test_minp_sampling_with_skewed_logits():
+  """With highly skewed logits, min-p should only keep the dominant token."""
+  sampling = gm.text.MinPSampling(min_p=0.5)
+  rng = jax.random.PRNGKey(0)
+  # Token 0 has probability ~0.99, others are negligible.
+  logits = jax.numpy.array([
+      [10.0, 0.0, 0.0, 0.0, 0.0],
+  ])
+  tokens = sampling.get_next_tokens(logits, rng)
+  # With min_p=0.5, threshold = 0.5 * 0.99 ≈ 0.49.
+  # Only token 0 (prob ~0.99) exceeds the threshold.
+  np.testing.assert_array_equal(tokens, [0])
+
+
+def test_minp_zero_disables_filtering():
+  """With min_p=0, all tokens should be candidates (no filtering)."""
+  sampling_off = gm.text.MinPSampling(min_p=0.0, temperature=1.0)
+  sampling_rand = gm.text.RandomSampling(temperature=1.0)
+  rng = jax.random.PRNGKey(42)
+  logits = jax.random.normal(rng, shape=(100, 5))
+  # With min_p=0, MinPSampling should behave like RandomSampling.
+  tokens_minp = sampling_off.get_next_tokens(logits, rng)
+  tokens_rand = sampling_rand.get_next_tokens(logits, rng)
+  np.testing.assert_array_equal(tokens_minp, tokens_rand)
+


### PR DESCRIPTION
## Summary

Add `MinPSampling` to the sampling methods in `gm.text`. Min-p sampling keeps all tokens whose probability is at least `min_p × max_probability`, dynamically adapting the candidate set based on model confidence — fewer candidates when the model is sure, more when uncertain.

This is widely adopted in llama.cpp, vLLM, and Hugging Face transformers. Reference: https://arxiv.org/abs/2407.01082

## Changes

- **`gemma/gm/text/_sampling.py`**: Added `MinPSampling` class following existing `SamplingMethod` patterns (frozen dataclass, `@typechecked`, temperature + min_p params)
- **`gemma/gm/text/_sampling_test.py`**: Added 3 tests — basic shape, skewed logits behavior, and `min_p=0` equivalence with `RandomSampling`
- **`gemma/gm/text/__init__.py`**: Exported `MinPSampling`, removed outdated TODO about nucleus sampling (already exists as `TopPSampling`)

## Test plan

- [x] All 9 sampling tests pass (`pytest -vv gemma/gm/text/_sampling_test.py`)
- [x] Full test suite passes (97/98; 1 failure is grain-related, Windows-expected)
- [x] Follows existing code patterns and Google style (2-space indent, pyink)