### PR TITLE
Broken error messages in token normalization—`{token!r}` shown literally instead of actual token value (#579)

### DIFF
--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -572,7 +572,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
+        f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
         ' map to single token ids in the vocab.'
     )
   (token_id,) = token_id

--- a/gemma/research/t5gemma/sampling.py
+++ b/gemma/research/t5gemma/sampling.py
@@ -510,7 +510,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
+        f'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
         ' single token ids in the vocab.'
     )
   (token_id,) = token_id


### PR DESCRIPTION
## Fix for Issue #579

### Root cause

In `_normalize_token`, when a `stop_token` or `forbidden_token` string maps to multiple token IDs, the code raises a `ValueError` using a **plain string** instead of an **f-string**:

```python
raise ValueError(
    'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
    ' map to single token ids in the vocab.'
)
```

Because there is no `f` prefix, Python treats `{token!r}` as literal text. Users see:

```text
ValueError: Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must map to single token ids in the vocab.
```

instead of the actual invalid token value, making debugging harder.

### Fix summary

Use an **f-string** so `{token!r}` is interpolated and the real token value appears in the error message. Apply the same change in both affected files.

### Patch sketch

**1. `gemma/gm/text/_sampler.py`**

```python
raise ValueError(
    f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
    ' map to single token ids in the vocab.'
)
```

**2. `gemma/research/t5gemma/sampling.py`**

```python
raise ValueError(
    f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
    ' map to single token ids in the vocab.'
)
```

<img width="759" height="157" alt="Screenshot 2026-02-19 at 9 01 44 PM" src="https://github.com/user-attachments/assets/19632453-6cd1-41e2-9eff-ecbddf699707" />
