### PR TITLE
test: add missing unit tests for untested modules

### DIFF
--- a/gemma/gm/ckpts/_paths_test.py
+++ b/gemma/gm/ckpts/_paths_test.py
@@ -1,0 +1,120 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for checkpoint paths."""
+
+import re
+
+from gemma.gm.ckpts import _paths
+
+
+class TestCheckpointPath:
+  """Tests for CheckpointPath enum."""
+
+  def test_is_str_enum(self):
+    """All enum values should be strings."""
+    for member in _paths.CheckpointPath:
+      assert isinstance(member.value, str)
+
+  def test_all_paths_start_with_gs(self):
+    """All checkpoint paths should be GCS paths."""
+    for member in _paths.CheckpointPath:
+      assert member.value.startswith('gs://'), (
+          f'{member.name} does not start with gs://: {member.value}'
+      )
+
+  def test_all_paths_contain_checkpoints(self):
+    """All paths should contain the 'checkpoints' directory."""
+    for member in _paths.CheckpointPath:
+      assert '/checkpoints/' in member.value, (
+          f'{member.name} missing /checkpoints/ in path: {member.value}'
+      )
+
+  def test_path_format_matches_name(self):
+    """Path basename should be a lowercased version consistent with the name.
+
+    E.g. GEMMA3_4B_IT -> gemma3-4b-it
+    """
+    for member in _paths.CheckpointPath:
+      basename = member.value.rsplit('/', 1)[-1]
+      # Convert name: GEMMA3_4B_IT -> gemma3-4b-it
+      expected = member.name.lower().replace('_', '-')
+      # Handle gemma3n enum names: GEMMA3N_E2B_IT -> gemma3n-e2b-it
+      assert basename == expected, (
+          f'{member.name}: expected basename {expected!r}, got {basename!r}'
+      )
+
+  def test_naming_convention_version_size_variant(self):
+    """All names should follow VERSION_SIZE_VARIANT pattern."""
+    pattern = re.compile(
+        r'^GEMMA[23N]*_'  # Version: GEMMA2, GEMMA3, GEMMA3N
+        r'(270M|1B|2B|4B|9B|12B|27B|E2B|E4B)_'  # Size
+        r'(PT|IT)$'  # Variant: Pre-trained or Instruction-Tuned
+    )
+    for member in _paths.CheckpointPath:
+      assert pattern.match(member.name), (
+          f'{member.name} does not match VERSION_SIZE_VARIANT pattern'
+      )
+
+  def test_pt_and_it_pairs_exist(self):
+    """Every model size should have both PT and IT variants."""
+    names = [m.name for m in _paths.CheckpointPath]
+    pt_names = {n.replace('_PT', '') for n in names if n.endswith('_PT')}
+    it_names = {n.replace('_IT', '') for n in names if n.endswith('_IT')}
+    assert pt_names == it_names, (
+        f'PT/IT mismatch. PT-only: {pt_names - it_names}, '
+        f'IT-only: {it_names - pt_names}'
+    )
+
+  def test_gemma2_models_exist(self):
+    """Gemma 2 should have 2B, 9B, 27B sizes."""
+    expected = {'GEMMA2_2B_PT', 'GEMMA2_9B_PT', 'GEMMA2_27B_PT',
+                'GEMMA2_2B_IT', 'GEMMA2_9B_IT', 'GEMMA2_27B_IT'}
+    names = {m.name for m in _paths.CheckpointPath}
+    assert expected.issubset(names)
+
+  def test_gemma3_models_exist(self):
+    """Gemma 3 should have 270M, 1B, 4B, 12B, 27B sizes."""
+    expected = {'GEMMA3_270M_PT', 'GEMMA3_1B_PT', 'GEMMA3_4B_PT',
+                'GEMMA3_12B_PT', 'GEMMA3_27B_PT',
+                'GEMMA3_270M_IT', 'GEMMA3_1B_IT', 'GEMMA3_4B_IT',
+                'GEMMA3_12B_IT', 'GEMMA3_27B_IT'}
+    names = {m.name for m in _paths.CheckpointPath}
+    assert expected.issubset(names)
+
+  def test_gemma3n_models_exist(self):
+    """Gemma 3N should have E2B and E4B sizes."""
+    expected = {'GEMMA3N_E2B_PT', 'GEMMA3N_E4B_PT',
+                'GEMMA3N_E2B_IT', 'GEMMA3N_E4B_IT'}
+    names = {m.name for m in _paths.CheckpointPath}
+    assert expected.issubset(names)
+
+  def test_str_enum_lookup(self):
+    """Should be able to use string value to look up the enum."""
+    path = 'gs://gemma-data/checkpoints/gemma3-4b-it'
+    member = _paths.CheckpointPath(path)
+    assert member is _paths.CheckpointPath.GEMMA3_4B_IT
+
+  def test_no_duplicate_paths(self):
+    """All paths should be unique."""
+    values = [m.value for m in _paths.CheckpointPath]
+    assert len(values) == len(set(values)), 'Duplicate checkpoint paths found'
+
+  def test_total_count(self):
+    """Verify the expected total number of checkpoints."""
+    # Gemma2: 3 sizes * 2 variants = 6
+    # Gemma3: 5 sizes * 2 variants = 10
+    # Gemma3N: 2 sizes * 2 variants = 4
+    # Total = 20
+    assert len(_paths.CheckpointPath) == 20

--- a/gemma/gm/data/_tasks_test.py
+++ b/gemma/gm/data/_tasks_test.py
@@ -1,0 +1,42 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for data tasks helpers."""
+
+from gemma.gm.data import _tasks
+
+
+class TestDecodeBytes:
+  """Tests for _decode_bytes helper."""
+
+  def test_bytes_decoded_to_str(self):
+    assert _tasks._decode_bytes(b'hello world') == 'hello world'
+
+  def test_str_passthrough(self):
+    assert _tasks._decode_bytes('already a string') == 'already a string'
+
+  def test_utf8_bytes(self):
+    text = 'café'
+    assert _tasks._decode_bytes(text.encode('utf-8')) == text
+
+  def test_empty_bytes(self):
+    assert _tasks._decode_bytes(b'') == ''
+
+  def test_empty_string(self):
+    assert _tasks._decode_bytes('') == ''
+
+  def test_non_string_passthrough(self):
+    """Non-bytes, non-string values should pass through unchanged."""
+    assert _tasks._decode_bytes(42) == 42
+    assert _tasks._decode_bytes(None) is None

--- a/gemma/gm/losses/_dpo_test.py
+++ b/gemma/gm/losses/_dpo_test.py
@@ -1,0 +1,167 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DPO loss."""
+
+from gemma.gm.losses import _dpo
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def _make_one_hot_logits(targets, vocab_size):
+  """Creates logits that are high for the target tokens."""
+  one_hot = jax.nn.one_hot(targets, vocab_size)
+  # Scale so softmax is strongly peaked at the target.
+  return one_hot * 10.0 - 5.0
+
+
+class TestGetLogprobsForTarget:
+  """Tests for _get_logprobs_for_target helper."""
+
+  def test_shape(self):
+    batch, n, seq_len, vocab = 2, 2, 4, 8
+    logits = jnp.ones((batch, n, seq_len, vocab))
+    targets = jnp.zeros((batch, n, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, n, seq_len), dtype=jnp.bool_)
+
+    result = _dpo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask,
+    )
+    assert result.shape == (batch, n)
+
+  def test_masked_tokens_ignored(self):
+    """Masked positions should not contribute to log-probs."""
+    vocab = 4
+    # B=1, N=1, L=3
+    logits = jnp.zeros((1, 1, 3, vocab))
+    targets = jnp.array([[[0, 1, 2]]], dtype=jnp.int32)
+
+    mask_all = jnp.ones((1, 1, 3), dtype=jnp.bool_)
+    mask_partial = jnp.array([[[True, False, False]]])
+
+    result_all = _dpo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask_all,
+    )
+    result_partial = _dpo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask_partial,
+    )
+    # Partial mask should give a less-negative (higher) value since fewer
+    # tokens contribute.
+    assert float(result_partial[0, 0]) > float(result_all[0, 0])
+
+  def test_perfect_logits_give_near_zero_logprob(self):
+    """When logits strongly favor the target, log-prob should be near 0."""
+    vocab = 4
+    targets = jnp.array([[[0, 1]]], dtype=jnp.int32)  # B=1, N=1, L=2
+    logits = _make_one_hot_logits(targets, vocab)
+    mask = jnp.ones((1, 1, 2), dtype=jnp.bool_)
+
+    result = _dpo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask,
+    )
+    # Sum of log-probs should be close to 0 (each token ~ log(1) = 0).
+    np.testing.assert_allclose(float(result[0, 0]), 0.0, atol=0.02)
+
+
+class TestDpoLoss:
+  """Tests for DpoLoss.get_values."""
+
+  def test_output_shape(self):
+    batch, n, seq_len, vocab = 2, 2, 4, 8
+    tokens = jnp.zeros((batch, n, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, n, seq_len), dtype=jnp.bool_)
+    logits = jnp.ones((batch, n, seq_len, vocab))
+
+    loss = _dpo.DpoLoss()
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=logits,
+        anchor_logits=logits,
+    )
+    assert result.shape == (batch, 1)
+
+  def test_zero_when_policy_equals_anchor(self):
+    """When policy == anchor, diff_logprob is 0 for both chosen/rejected.
+
+    po_delta = 0, so loss = -(log_sigmoid(0)*(1-ls) + log_sigmoid(0)*ls)
+                           = -log_sigmoid(0) = -log(0.5) = log(2).
+    """
+    batch, n, seq_len, vocab = 1, 2, 3, 4
+    rng = jax.random.PRNGKey(42)
+    logits = jax.random.normal(rng, (batch, n, seq_len, vocab))
+    tokens = jnp.zeros((batch, n, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, n, seq_len), dtype=jnp.bool_)
+
+    loss = _dpo.DpoLoss(tau=0.1, label_smoothing=0.0)
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=logits,
+        anchor_logits=logits,
+    )
+    # po_delta = 0 => loss = -log_sigmoid(0) = log(2)
+    np.testing.assert_allclose(
+        float(result[0, 0]), np.log(2), atol=1e-5
+    )
+
+  def test_loss_is_non_negative(self):
+    """DPO loss should always be non-negative."""
+    batch, n, seq_len, vocab = 3, 2, 5, 8
+    rng = jax.random.PRNGKey(0)
+    k1, k2 = jax.random.split(rng)
+    policy_logits = jax.random.normal(k1, (batch, n, seq_len, vocab))
+    anchor_logits = jax.random.normal(k2, (batch, n, seq_len, vocab))
+    tokens = jax.random.randint(k1, (batch, n, seq_len), 0, vocab)
+    mask = jnp.ones((batch, n, seq_len), dtype=jnp.bool_)
+
+    loss = _dpo.DpoLoss(tau=0.1, label_smoothing=0.0)
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    assert jnp.all(result >= 0.0)
+
+  def test_label_smoothing_effect(self):
+    """Label smoothing should change the loss value."""
+    batch, n, seq_len, vocab = 1, 2, 3, 4
+    rng = jax.random.PRNGKey(7)
+    k1, k2 = jax.random.split(rng)
+    policy_logits = jax.random.normal(k1, (batch, n, seq_len, vocab))
+    anchor_logits = jax.random.normal(k2, (batch, n, seq_len, vocab))
+    tokens = jnp.zeros((batch, n, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, n, seq_len), dtype=jnp.bool_)
+
+    loss_no_smooth = _dpo.DpoLoss(tau=0.1, label_smoothing=0.0)
+    loss_smooth = _dpo.DpoLoss(tau=0.1, label_smoothing=0.5)
+
+    result_no_smooth = loss_no_smooth.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    result_smooth = loss_smooth.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    # With label_smoothing=0.5, loss = -log_sigmoid(x)*0.5 - log_sigmoid(-x)*0.5
+    # = -0.5*(log_sigmoid(x) + log_sigmoid(-x))
+    # which differs from label_smoothing=0.0 unless po_delta=0.
+    assert not jnp.allclose(result_no_smooth, result_smooth)

--- a/gemma/gm/losses/_npo_test.py
+++ b/gemma/gm/losses/_npo_test.py
@@ -1,0 +1,153 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NPO loss."""
+
+from gemma.gm.losses import _npo
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+class TestGetLogprobsForTarget:
+  """Tests for _get_logprobs_for_target helper."""
+
+  def test_shape(self):
+    batch, seq_len, vocab = 2, 4, 8
+    logits = jnp.ones((batch, seq_len, vocab))
+    targets = jnp.zeros((batch, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, seq_len), dtype=jnp.bool_)
+
+    result = _npo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask,
+    )
+    assert result.shape == (batch,)
+
+  def test_logprobs_are_negative(self):
+    """Log-probabilities should always be <= 0."""
+    batch, seq_len, vocab = 3, 5, 8
+    rng = jax.random.PRNGKey(0)
+    logits = jax.random.normal(rng, (batch, seq_len, vocab))
+    targets = jnp.zeros((batch, seq_len), dtype=jnp.int32)
+    mask = jnp.ones((batch, seq_len), dtype=jnp.bool_)
+
+    result = _npo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask,
+    )
+    assert jnp.all(result <= 0.0)
+
+  def test_masked_tokens_ignored(self):
+    """Masked positions should not contribute to log-probs."""
+    vocab = 4
+    logits = jnp.zeros((1, 3, vocab))
+    targets = jnp.array([[0, 1, 2]], dtype=jnp.int32)
+
+    mask_all = jnp.ones((1, 3), dtype=jnp.bool_)
+    mask_first_only = jnp.array([[True, False, False]])
+
+    result_all = _npo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask_all,
+    )
+    result_partial = _npo._get_logprobs_for_target(
+        logits=logits, targets=targets, sequence_mask=mask_first_only,
+    )
+    # Fewer tokens summed => less-negative value.
+    assert float(result_partial[0]) > float(result_all[0])
+
+
+class TestNpoLoss:
+  """Tests for NpoLoss.get_values."""
+
+  def test_output_shape(self):
+    batch, seq_len, vocab = 2, 4, 8
+    tokens = jnp.zeros((batch, seq_len, 1), dtype=jnp.int32)
+    mask = jnp.ones((batch, seq_len, 1), dtype=jnp.bool_)
+    logits = jnp.ones((batch, seq_len, vocab))
+
+    loss = _npo.NpoLoss()
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=logits,
+        anchor_logits=logits,
+    )
+    assert result.shape == (batch, 1)
+
+  def test_zero_delta_when_policy_equals_anchor(self):
+    """When policy == anchor, po_delta = 0.
+
+    NPO loss = -log_sigmoid(0) = -log(0.5) = log(2).
+    """
+    batch, seq_len, vocab = 1, 3, 4
+    rng = jax.random.PRNGKey(42)
+    logits = jax.random.normal(rng, (batch, seq_len, vocab))
+    tokens = jnp.zeros((batch, seq_len, 1), dtype=jnp.int32)
+    mask = jnp.ones((batch, seq_len, 1), dtype=jnp.bool_)
+
+    loss = _npo.NpoLoss(tau=1.0)
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=logits,
+        anchor_logits=logits,
+    )
+    np.testing.assert_allclose(
+        float(result[0, 0]), np.log(2), atol=1e-5
+    )
+
+  def test_loss_is_non_negative(self):
+    """NPO loss should always be non-negative."""
+    batch, seq_len, vocab = 3, 5, 8
+    rng = jax.random.PRNGKey(0)
+    k1, k2 = jax.random.split(rng)
+    policy_logits = jax.random.normal(k1, (batch, seq_len, vocab))
+    anchor_logits = jax.random.normal(k2, (batch, seq_len, vocab))
+    tokens = jax.random.randint(k1, (batch, seq_len, 1), 0, vocab)
+    mask = jnp.ones((batch, seq_len, 1), dtype=jnp.bool_)
+
+    loss = _npo.NpoLoss(tau=1.0)
+    result = loss.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    assert jnp.all(result >= 0.0)
+
+  def test_tau_scales_loss(self):
+    """Different tau values should produce different losses."""
+    batch, seq_len, vocab = 1, 3, 4
+    rng = jax.random.PRNGKey(7)
+    k1, k2 = jax.random.split(rng)
+    policy_logits = jax.random.normal(k1, (batch, seq_len, vocab))
+    anchor_logits = jax.random.normal(k2, (batch, seq_len, vocab))
+    tokens = jnp.zeros((batch, seq_len, 1), dtype=jnp.int32)
+    mask = jnp.ones((batch, seq_len, 1), dtype=jnp.bool_)
+
+    loss_tau1 = _npo.NpoLoss(tau=1.0)
+    loss_tau5 = _npo.NpoLoss(tau=5.0)
+
+    result_tau1 = loss_tau1.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    result_tau5 = loss_tau5.get_values(
+        tokens=tokens,
+        sequence_mask=mask,
+        policy_logits=policy_logits,
+        anchor_logits=anchor_logits,
+    )
+    assert not jnp.allclose(result_tau1, result_tau5)

--- a/gemma/gm/math/_pos_utils_test.py
+++ b/gemma/gm/math/_pos_utils_test.py
@@ -1,0 +1,68 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for position utilities."""
+
+from gemma.gm.math import _pos_utils
+import jax.numpy as jnp
+import numpy as np
+
+
+class TestBuildPositionsFromMask:
+  """Tests for build_positions_from_mask."""
+
+  def test_all_valid_tokens(self):
+    """All tokens valid => positions should be [0, 1, 2, ...]."""
+    mask = jnp.array([True, True, True, True])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    np.testing.assert_array_equal(positions, [0, 1, 2, 3])
+
+  def test_leading_padding(self):
+    """Padding at the start: valid tokens should still be 0-indexed."""
+    mask = jnp.array([False, False, True, True, True])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    # First valid token gets position 0, then 1, 2.
+    expected = [0, 0, 0, 1, 2]
+    np.testing.assert_array_equal(positions, expected)
+
+  def test_all_padding(self):
+    """All padded => cumsum is 0 everywhere, positions stay 0."""
+    mask = jnp.array([False, False, False])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    np.testing.assert_array_equal(positions, [0, 0, 0])
+
+  def test_single_token(self):
+    """Single valid token should get position 0."""
+    mask = jnp.array([True])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    np.testing.assert_array_equal(positions, [0])
+
+  def test_batched_input(self):
+    """Should work with batched (2D) input masks."""
+    mask = jnp.array([
+        [True, True, True, False],
+        [False, True, True, True],
+    ])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    expected = jnp.array([
+        [0, 1, 2, 2],
+        [0, 0, 1, 2],
+    ])
+    np.testing.assert_array_equal(positions, expected)
+
+  def test_output_shape(self):
+    """Output shape should match input shape."""
+    mask = jnp.array([True, True, False])
+    positions = _pos_utils.build_positions_from_mask(mask)
+    assert positions.shape == (3,)

--- a/gemma/gm/tools/_manager_test.py
+++ b/gemma/gm/tools/_manager_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tool manager base class."""
+
+from collections.abc import Iterator
+import contextlib
+import dataclasses
+from typing import Any
+from unittest import mock
+
+from gemma.gm.tools import _manager
+import mcp.types
+import pytest
+
+
+# Concrete implementation for testing the abstract base class.
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _FakeToolHandler(_manager.ToolHandlerBase):
+  """A minimal concrete ToolHandlerBase for testing."""
+
+  fake_tools: tuple[mcp.types.Tool, ...] = ()
+
+  def _tools(self):
+    return list(self.fake_tools)
+
+  def _call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+    return mcp.types.CallToolResult(
+        content=[mcp.types.TextContent(type='text', text=f'result:{name}')],
+    )
+
+
+class TestToolHandlerBase:
+  """Tests for ToolHandlerBase abstract class."""
+
+  def test_is_active_false_by_default(self):
+    handler = _FakeToolHandler()
+    assert handler.is_active is False
+
+  def test_context_manager_activates(self):
+    handler = _FakeToolHandler()
+    with handler:
+      assert handler.is_active is True
+    assert handler.is_active is False
+
+  def test_nested_context_manager_does_not_raise(self):
+    """Entering context when already active should not raise."""
+    handler = _FakeToolHandler()
+    with handler:
+      assert handler.is_active is True
+      with handler:  # Nested — should not fail.
+        pass  # No crash is the key guarantee.
+
+  def test_tools_property(self):
+    tool = mcp.types.Tool(
+        name='test_tool',
+        description='A test tool',
+        inputSchema={'type': 'object', 'properties': {}},
+    )
+    handler = _FakeToolHandler(fake_tools=(tool,))
+    tools = handler.tools
+    assert len(tools) == 1
+    assert tools[0].name == 'test_tool'
+
+  def test_call_tool(self):
+    handler = _FakeToolHandler()
+    result = handler.call_tool(name='my_func', arguments={'a': 1})
+    assert isinstance(result, mcp.types.CallToolResult)
+    assert result.content[0].text == 'result:my_func'
+
+
+class TestNormalizeResponse:
+  """Tests for _normalize_response helper."""
+
+  def test_text_response_gets_structured_content(self):
+    """A plain text response should be wrapped in structuredContent."""
+    response = mcp.types.CallToolResult(
+        content=[mcp.types.TextContent(type='text', text='hello')],
+    )
+    normalized = _manager._normalize_response(response)
+    assert normalized.structuredContent == {'result': 'hello'}
+
+  def test_error_response_gets_error_key(self):
+    """An error response should use 'error' key in structuredContent."""
+    response = mcp.types.CallToolResult(
+        content=[mcp.types.TextContent(type='text', text='something failed')],
+        isError=True,
+    )
+    normalized = _manager._normalize_response(response)
+    assert normalized.structuredContent == {'error': 'something failed'}
+
+  def test_already_structured_response_unchanged(self):
+    """If structuredContent already set, it should be returned as-is."""
+    response = mcp.types.CallToolResult(
+        content=[mcp.types.TextContent(type='text', text='ignored')],
+        structuredContent={'custom': 'data'},
+    )
+    normalized = _manager._normalize_response(response)
+    assert normalized.structuredContent == {'custom': 'data'}

--- a/gemma/gm/utils/_py_test.py
+++ b/gemma/gm/utils/_py_test.py
@@ -1,0 +1,120 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Python utilities."""
+
+import dataclasses
+
+from gemma.gm.utils import _py
+
+
+class TestFrozenDataclass:
+  """Tests for FrozenDataclass mixin."""
+
+  def test_equal_instances(self):
+    """Two instances with same fields should be equal."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+      y: str = 'hello'
+
+    a = Cfg(x=1, y='hello')
+    b = Cfg(x=1, y='hello')
+    assert a == b
+
+  def test_not_equal_instances(self):
+    """Two instances with different fields should not be equal."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+
+    a = Cfg(x=1)
+    b = Cfg(x=2)
+    assert a != b
+
+  def test_hash_equal_for_equal_instances(self):
+    """Equal instances must have the same hash."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+      y: str = 'hello'
+
+    a = Cfg(x=1, y='hello')
+    b = Cfg(x=1, y='hello')
+    assert hash(a) == hash(b)
+
+  def test_hash_differs_for_different_instances(self):
+    """Different instances should (usually) have different hashes."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+
+    a = Cfg(x=1)
+    b = Cfg(x=2)
+    # Not guaranteed, but very likely for distinct ints.
+    assert hash(a) != hash(b)
+
+  def test_usable_in_set(self):
+    """FrozenDataclass instances should be usable as set elements."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+
+    a = Cfg(x=1)
+    b = Cfg(x=1)
+    c = Cfg(x=2)
+    s = {a, b, c}
+    assert len(s) == 2
+
+  def test_usable_as_dict_key(self):
+    """FrozenDataclass instances should be usable as dict keys."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+
+    key = Cfg(x=42)
+    d = {key: 'value'}
+    assert d[Cfg(x=42)] == 'value'
+
+  def test_compare_false_is_excluded(self):
+    """Fields with compare=False should not affect equality or hash."""
+
+    @dataclasses.dataclass(eq=False)
+    class Cfg(_py.FrozenDataclass):
+      x: int = 1
+      meta: str = dataclasses.field(default='a', compare=False)
+
+    a = Cfg(x=1, meta='a')
+    b = Cfg(x=1, meta='b')
+    assert a == b
+    assert hash(a) == hash(b)
+
+  def test_not_equal_to_different_class(self):
+    """Instances of different classes should not be equal."""
+
+    @dataclasses.dataclass(eq=False)
+    class CfgA(_py.FrozenDataclass):
+      x: int = 1
+
+    @dataclasses.dataclass(eq=False)
+    class CfgB(_py.FrozenDataclass):
+      x: int = 1
+
+    assert CfgA(x=1) != CfgB(x=1)


### PR DESCRIPTION
Add tests for modules that previously had zero test coverage:

- gemma/gm/losses/_dpo_test.py: DPO loss shape, non-negativity, label smoothing
- gemma/gm/losses/_npo_test.py: NPO loss shape, non-negativity, tau scaling
- gemma/gm/ckpts/_paths_test.py: CheckpointPath enum validation, naming conventions
- gemma/gm/math/_pos_utils_test.py: build_positions_from_mask correctness
- gemma/gm/utils/_py_test.py: FrozenDataclass equality, hashing, sets/dicts
- gemma/gm/tools/_manager_test.py: ToolHandlerBase context manager, _normalize_response
- gemma/gm/data/_tasks_test.py: _decode_bytes helper