### PR TITLE
refactor: use jnp.take_along_axis for return_last_only indexing

### DIFF
--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -250,8 +250,10 @@ class Transformer(nn.Module):
 
     if return_last_only:
       last_input_token_idx = jnp.sum(inputs.inputs_mask, axis=-1) - 1
-      # TODO(epot): Use `jnp.take_along_axis`
-      x = x[jnp.arange(len(x)), last_input_token_idx, ...]
+      x = jnp.take_along_axis(
+          x, last_input_token_idx[:, None, None], axis=1
+      )
+      x = jnp.squeeze(x, axis=1)
     elif images is not None:
       # Remove the MM extra tokens inserted.
       # During fine-tuning, the prompt is always masked, and the model cannot

--- a/gemma/gm/nn/gemma3n/_transformer.py
+++ b/gemma/gm/nn/gemma3n/_transformer.py
@@ -320,8 +320,10 @@ class Gemma3nTransformer(_transformer.Transformer):
 
     if return_last_only:
       last_input_token_idx = jnp.sum(inputs.inputs_mask, axis=-1) - 1
-      # TODO(epot): Use `jnp.take_along_axis`
-      x = x[jnp.arange(len(x)), last_input_token_idx, ...]
+      x = jnp.take_along_axis(
+          x, last_input_token_idx[:, None, None], axis=1
+      )
+      x = jnp.squeeze(x, axis=1)
     elif images is not None:
       # Remove the MM extra tokens inserted.
       # During fine-tuning, the prompt is always masked, and the model cannot


### PR DESCRIPTION
## Summary

Resolves `TODO(epot): Use jnp.take_along_axis` in both `Transformer.__call__` and `Gemma3nTransformer.__call__`.

The `return_last_only` code path previously used manual fancy indexing with `jnp.arange` to select the last non-padded token per batch element. This replaces it with `jnp.take_along_axis`, which is cleaner and avoids constructing an index array.

## Changes

- **`gemma/gm/nn/_transformer.py`** (line ~253): replaced `x[jnp.arange(len(x)), idx, ...]` with `jnp.take_along_axis(x, idx[:, None, None], axis=1)` + squeeze
- **`gemma/gm/nn/gemma3n/_transformer.py`** (line ~323): same change

## Test plan

- [x] `test_prefill` passes (exercises `return_last_only=True` via the standard Transformer)
- [x] `test_sampler` passes (end-to-end sampling using prefill)
- [x] `test_last_only` passes (directly tests `return_last_only` on Gemma3n)
- [x] All 9 relevant tests pass