### PR TITLE
docs: Add Python 3.11+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ For examples and use cases, see our
 report issues and feedback in
 [our GitHub](https://github.com/google-deepmind/gemma/issues).
 
+### Prerequisites
+
+* **Python 3.11 or higher:** This library requires modern Python components (e.g. Kauldron and JAX). Using an older Python version (**3.10 or lower**) will cause `pip` to install an unrelated "gemma" package from 2020, resulting in `ImportError: cannot import name 'gm'`.
+
 ### Installation
 
 1.  Install JAX for CPU, GPU or TPU. Follow the instructions on


### PR DESCRIPTION
Adds a Prerequisites section to the README to fix a common installation pitfall. Users running Python 3.10 or lower who attempt to pip install gemma are served an unrelated, legacy data-mapping package (v1.2.2) from 2020.