### PR TITLE
Update: Replace "Coming Soon" with Official Landing Page Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ contain additional scripts to fine-tune and sample with Gemma.
   * [Gemma 1](https://goo.gle/GemmaReport)
   * [Gemma 2](https://goo.gle/gemma2report)
   * [Gemma 3](https://storage.googleapis.com/deepmind-media/gemma/Gemma3Report.pdf)
-  * Gemma 4 (Coming soon)
+  * [Gemma 4 ](https://deepmind.google/models/gemma/gemma-4/)
 * Other Gemma implementations and doc on the
   [Gemma ecosystem](https://ai.google.dev/gemma/docs)
 


### PR DESCRIPTION
As the issue mentions there was a typo in readme that on front of gemma 4 there was written as coming soon still gemma4 was officially released on 2 April 2026 

<img width="441" height="132" alt="image" src="https://github.com/user-attachments/assets/ec7b3bef-a943-4471-94ee-ff409a186407" />

Changes made:

1 . Removed the "Coming Soon" bracket/placeholder
2 . Added a redirect to the official landing page

Reason:
The "Coming Soon" label is no longer relevant. Redirecting users to the official landing page provides immediate access to accurate and up-to-date information.

<img width="570" height="131" alt="image" src="https://github.com/user-attachments/assets/e997f026-1a27-4392-883e-ad0b3a41b476" />
