### PR TITLE
KV Cache Memory and Sharding

### DIFF
--- a/KV_CACHE_DESIGN.md
+++ b/KV_CACHE_DESIGN.md
@@ -1,0 +1,800 @@
+# Gemma JAX KV Cache: Memory & Sharding Design Proposal
+
+**Author:** Karl (with Claude Code assistance)
+**Status:** Updated after design review
+**Target:** `github.com/google-deepmind/gemma` (this repo)
+**Date:** 2026-05-09
+**Related code paths:**
+- [`gemma/gm/text/_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py)
+- [`gemma/gm/text/_chat_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py)
+- [`gemma/gm/text/_gemma4_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py)
+- [`gemma/gm/text/_prefill.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py)
+- [`gemma/gm/text/_sampler_loop.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler_loop.py)
+- [`gemma/gm/nn/gemma4/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py)
+- [`gemma/gm/nn/gemma4/_modules.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py)
+- [`gemma/gm/nn/gemma4/_transformer.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py)
+- [`gemma/gm/utils/_cache_helper.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py)
+
+---
+
+## 1. Problem Statement
+
+The `gm.text.ChatSampler` / `gm.text.Gemma4Sampler` inference path is
+substantially less HBM-efficient than necessary on multi-chip TPU slices,
+specifically for the Gemma 4 model family which uses hybrid
+local-sliding + global attention. Two independent issues compound:
+
+**Problem A — Eager, uniform cache allocation across all layers.**
+At sampler construction time (more precisely at the start of every
+non-multi-turn prefill call), the cache is allocated as a fixed
+`[batch, cache_length, num_kv_heads, head_dim]` buffer **identically
+sized on every layer**, including layers whose attention type is
+`LOCAL_SLIDING` and which only ever read the most recent
+`sliding_window_size` tokens during causal decode
+([`gemma4/_modules.py:343-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L343-L349)
+masks all positions outside the window). For a Gemma 4 model that uses a
+5L:1G pattern (E4B has 35 local + 7 global; 31B has 50 local + 10 global;
+26B-A4B has 25 local + 5 global), most of the per-layer cache budget is
+zeroed bytes that the attention mask discards. The waste fraction grows
+linearly with `cache_length` until at long contexts the cache is
+dominated by guaranteed-unread bytes.
+
+**Problem B — Cache is replicated across the device slice.**
+At all current call sites
+([`gemma4/_transformer.py:412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L412),
+[`_transformer.py:329`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_transformer.py#L329),
+[`gemma3n/_transformer.py:370`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_transformer.py#L370))
+the cache pytree is passed to
+`kd.sharding.with_sharding_constraint(cache, sharding)` with no
+intrinsic, model-aware partition spec. The user-facing samplers
+(`Sampler`, `Gemma4Sampler`, `ChatSampler`) accept a `sharding=` kwarg
+but the documented usage path
+([`colabs/sharding.ipynb`](https://github.com/google-deepmind/gemma/blob/main/colabs/sharding.ipynb))
+does not pass one. With `sharding=None` the constraint is a no-op and
+the cache lives wherever the active mesh / JIT default puts it. With
+FSDP-sharded params and no explicit cache sharding, the cache gets
+**replicated across every chip** — same memory cost on every chip in
+the slice, scaling 1× rather than 1/N×.
+
+The combination is a multiplicative loss: every chip pays for cache
+slots that are never read. On memory-constrained slices (16 GB / chip
+on TPU v5e) it is the dominant blocker for running the larger Gemma 4
+variants (31B, 26B-A4B) at any usable context length, and a soft
+blocker for E2B/E4B at long contexts (≥16K).
+
+### 1.1. Empirical evidence
+
+Two scripts ([`examples/cache_audit.py`](./examples/cache_audit.py) and
+[`examples/cache_probe.py`](./examples/cache_probe.py), included in
+this proposal) collect the following data on a v5e-4 slice (4 chips,
+16 GB HBM each, FSDP-sharded params):
+
+**Cache audit, Gemma4_E4B (35 LOCAL_SLIDING + 7 GLOBAL layers,
+`num_kv_heads=2`, `head_dim=256` local / 512 global,
+`sliding_window_size=512`):**
+
+| `cache_length` | Total cache bytes | LOCAL bytes | GLOBAL bytes | Ratio vs L=256 |
+|---:|---:|---:|---:|---:|
+|   256 |   24.54 MiB |  17.53 MiB |   7.01 MiB | 1.00× |
+| 4 096 |  392.66 MiB | 280.55 MiB | 112.11 MiB | 16.00× |
+|16 384 | 1 506.11 MiB | 1 100 MiB | 448 MiB | 64.00× |
+
+The ratio is **exactly linear in `cache_length` across every layer**,
+including all 35 local-sliding layers. With a `sliding_window_size=512`,
+the local layers only ever read `<= 512` slots; at `cache_length=16384`
+the local-attention storage is **31× over-allocated per local layer**
+(15 872 unread slots for every 512 read).
+
+**Runtime probe, Gemma4_E4B, ChatSampler with FSDP-sharded params,
+single chat() turn (~25 output tokens):**
+
+| Metric | L=4 096 | L=16 384 |
+|---|---:|---:|
+| HBM after params load (per chip) | 7.81 GiB | 7.81 GiB |
+| Peak HBM during chat (chip 0) | 9.46 GiB | 14.04 GiB |
+| Peak HBM during chat (chips 1-3) | 9.37 GiB | 13.95 GiB |
+| **Per-chip peak Δ** | **+1.6 GiB** | **+6.2 GiB** |
+| Per-chip post-chat Δ (steady state) | +800 MiB | +3.08 GiB |
+
+Interpretation:
+
+1. The peak deltas are roughly equal across all 4 chips (chip 0 is only
+   ~90 MiB above the others). This **confirms Problem B with replication
+   semantics**: every chip absorbs the full cache cost.
+2. The post-chat steady-state delta of ~800 MiB at L=4096 is roughly
+   **2× the logical cache size** (392 MiB). The extra ~400 MiB is the
+   `last_state.cache` held by `ChatSampler` plus a transient second
+   copy created by the functional update in `_merge_cache`
+   ([`_prefill.py:357-366`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L357-L366)).
+3. At L=16384 the per-chip peak exceeds 14 GiB out of a 15.75 GiB chip
+   limit. With ~6 GiB of headroom for activations/intermediate buffers
+   already consumed, this is the regime where small jit-time
+   re-allocations OOM — matching the originally reported
+   "32 MB allocation fails with chip 0 at near-zero free" symptom on
+   the bigger models (31B / 26B-A4B).
+
+### 1.2. Why this matters for production-style usage on TPU v5e
+
+The repo's stated audience for this sampler is research/experimentation
+([`gm.text.Sampler` docstring](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py#L86)
+explicitly recommends `gm.text.ChatSampler` "for most use cases"). But
+the sampler is the only ergonomic in-repo path to evaluate Gemma 4 on a
+TPU slice without standing up a separate inference engine. Closing
+even half the gap between the current implementation and a
+production-quality KV cache layout (à la MaxText / JetStream) makes
+the official sampler a viable evaluation tool for the larger Gemma 4
+variants on commodity TPU slices.
+
+### 1.3. Out of scope
+
+The following are intentionally NOT in scope for this proposal:
+
+- **PagedAttention / vLLM-style block-table caches.** Significant
+  surgery (block tables, Pallas gather kernels, ragged attention math).
+  Only a clear win for batched, multi-tenant serving with
+  heterogeneous request lengths. For a research sampler with batch=1
+  the eager-buffer approach is fine *once* Problems A and B are fixed.
+- **Quantized KV cache** (int8 / fp8). Independent axis of
+  improvement; can be layered on top of either fix.
+- **Cross-sampler refactor** (unifying `Sampler` / `Gemma4Sampler` /
+  `ChatSampler`). This proposal touches their shared dependencies but
+  preserves their public interfaces.
+
+---
+
+## 2. Code Archaeology
+
+### 2.1. Cache data structure
+
+The cache is a **plain `dict[str, dict[str, jax.Array]]`** keyed by
+`f"layer_{i}"`, with no axis-aware annotations:
+
+```
+type alias:  Cache = dict[str, _modules.LayerCache]
+type alias:  LayerCache = dict[str, jax.Array]
+```
+
+Defined at
+[`gemma/gm/nn/_config.py:28`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_config.py#L28)
+(legacy) and
+[`gemma/gm/nn/gemma4/_config.py:29`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L29)
+(Gemma 4). Per layer, four arrays:
+
+| Field | Shape | Dtype | Role |
+|---|---|---|---|
+| `'k'` | `[B, cache_size, num_kv_heads, head_dim]` | bf16 | key cache |
+| `'v'` | `[B, cache_size, num_kv_heads, head_dim]` | bf16 | value cache |
+| `'positions'` | `[B, cache_size]` | int32 | per-slot RoPE position (used by sliding mask) |
+| `'end_index'` | `[B]` | int32 | write pointer (mod cache_size) |
+
+A thin slicing wrapper exists
+([`_cache_helper.Cache`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L31-L89))
+but it just wraps the dict — it doesn't change the underlying layout.
+
+### 2.2. Allocation and sharding
+
+**Single-shot allocation per first-turn `sample()` / `chat()` call.**
+The full call chain for Gemma 4:
+
+1. User → `Gemma4Sampler.sample()` /
+   `ChatSampler.chat()` ([`_chat_sampler.py:261`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L261)).
+2. → `_prefill.prefill(... cache_length=self.cache_length, sharding=sharding)` ([`_gemma4_sampler.py:206`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py#L206)).
+3. → `_get_or_init_cache()` ([`_prefill.py:283-307`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L283-L307)).
+4. → `model.init_cache(...)` ([`_prefill.py:295-300`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L295-L300)).
+5. → `Gemma4Transformer.init_cache` ([`gemma4/_transformer.py:399-412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L399-L412), `nn.jit`-decorated, static_argnames includes `cache_length`, `sharding`, etc.).
+6. → `TransformerConfig.init_cache` ([`gemma4/_config.py:157-193`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L157-L193)).
+7. → `_modules.Attention.init_cache` ([`gemma4/_modules.py:397-417`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L397-L417)) — `jnp.zeros(...)` per layer.
+
+The sharding plumbing is a single
+`kd.sharding.with_sharding_constraint(cache, sharding)` over the entire
+pytree at
+[`gemma4/_transformer.py:412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L412):
+
+```python
+return kd.sharding.with_sharding_constraint(cache, sharding)
+```
+
+If the user does not pass a `sharding=` argument (the documented
+pattern), this is a no-op. The cache then takes the JAX default
+placement, which inside an active FSDP mesh is **replicated** (as
+confirmed by the runtime probe).
+
+**`cache_length` source.** A user-tunable field on the sampler, default
+4096
+([`_sampler.py:137`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py#L137),
+[`_gemma4_sampler.py:76`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py#L76),
+[`_chat_sampler.py:127`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L127)).
+Used as a single integer argument applied uniformly to every layer in
+[`gemma4/_config.py:171-192`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L171-L192).
+
+**Allocation frequency.** Once per first-turn `sample()` / `chat()`. In
+multi-turn mode, the cache is reused across turns
+([`_prefill.py:301-303`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L301-L303):
+`cache = prev_turns.cache`).
+
+### 2.3. The local-sliding waste, exposed
+
+The structural location of Problem A is
+[`gemma4/_config.py:171-192`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L171-L192):
+
+```python
+for i, attn_type in enumerate(self.attention_types):
+  if (attn_type == _modules.AttentionType.GLOBAL
+      and self.global_key_size is not None):
+    cache[f'layer_{i}'] = _modules.Attention.init_cache(
+        cache_length,                                            # uniform
+        self.num_global_kv_heads if self.num_global_kv_heads
+        else self.num_kv_heads,
+        self.global_key_size,
+        batch_size, dtype)
+  else:
+    cache[f'layer_{i}'] = _modules.Attention.init_cache(
+        cache_length,                                            # uniform
+        self.num_kv_heads,
+        self.head_dim,
+        batch_size, dtype)
+```
+
+The two branches differ in `num_kv_heads` and `head_dim` only. The
+`cache_length` argument is identical for global and local-sliding
+layers. The mask in
+[`gemma4/_modules.py:338-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L338-L349)
+already discards everything outside the window — no slot beyond
+`sliding_window_size` is ever attended to in a local-sliding layer.
+
+The same pattern exists in
+[`gemma3n/_config.py:178-194`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_config.py#L178-L194).
+The original Gemma 1-3 path
+([`gemma/gm/nn/_config.py:120-142`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_config.py#L120-L142))
+is uniform but Gemma 1-3 don't have hybrid attention, so it's not a
+loss there.
+
+### 2.4. Decode-step writes
+
+Each decode step writes one slot via `dynamic_update_slice` /
+`array.at[...].set(...)` into the pre-allocated buffer; there is no
+physical growth. The write index uses modular wrap (`end_index %
+cache_size` at
+[`gemma4/_modules.py:304`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L304))
+but the loop halts before the wrap matters — `cond_fn` checks
+`is_full = end_index >= total_cache_length - 1`
+([`_cache_helper.py:86-89`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L86-L89),
+[`_sampler_loop.py:160-171`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler_loop.py#L160-L171)).
+The mod-wrap is defensive, not load-bearing.
+
+### 2.5. The "is_full" first-layer assumption
+
+`Cache.total_cache_length` reads `next(iter(self.cache.values()))['k'].shape[1]`
+([`_cache_helper.py:43-47`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L43-L47)).
+It assumes every layer has the same cache length. **Any change that
+introduces per-layer cache sizes must update this method** to either
+(a) return the max across layers, or (b) be replaced with per-layer
+queries.
+
+---
+
+## 3. Proposed Changes
+
+This proposal includes **two independent but composable changes**,
+ranked by HBM impact at long context. Either can be merged
+independently.
+
+### 3.1. Change A: right-size LOCAL_SLIDING cache to the window
+
+**Summary.** Cap each local-sliding layer's cache size at
+`min(cache_length, sliding_window_size)`. Global layers retain the
+full `cache_length`.
+
+The implementation should be toggled with `KVCacheMode`, defaulting to
+`LEGACY`, and prefill should expose `KVPrefillMode.LEGACY_SCRATCH`
+through `GEMMA_KV_PREFILL_MODE=legacy_scratch` so benchmarks can record
+the active prefill strategy explicitly.
+
+**Why not "+1".** The window mask at
+[`gemma4/_modules.py:50-51`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L50-L51)
+uses strict bounds: `cache_position > position - sliding_window_size`
+and `cache_position < position + sliding_window_size`. With the normal
+causal mask during decode, that admits the current token plus the
+previous `sliding_window_size - 1` tokens. The persistent causal local
+cache therefore needs exactly `sliding_window_size` slots, not
+`sliding_window_size + 1`.
+
+**HBM saved (E4B, batch=1, bf16, per chip if currently replicated):**
+
+| `cache_length` | Current local cache | After change | Savings per chip |
+|---:|---:|---:|---:|
+|   4 096 | 280 MiB |  35 MiB | **245 MiB** |
+|  16 384 | 1.10 GiB |  35 MiB | **1.07 GiB** |
+|  32 768 | 2.19 GiB |  35 MiB | **2.16 GiB** |
+| 131 072 | 8.75 GiB |  35 MiB | **8.72 GiB** |
+
+(Local-cache size becomes constant once `cache_length >= window`. The
+~35 MiB figure for E4B is `35 layers x 1 x 512 x 2 x 256 x 2(k+v) x 2 B`.)
+
+For 31B (50 local + 10 global, sliding_window=1024, num_kv_heads=16
+local / 4 global): savings scale by ~ `50/35 × 16/2 ≈ 11×` versus E4B
+in absolute terms.
+
+**Implementation.**
+
+Patch [`gemma/gm/nn/gemma4/_config.py:157-193`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L157-L193):
+
+```python
+def init_cache(self, batch_size, dtype=jnp.bfloat16, *, cache_length):
+  if cache_length is None:
+    raise ValueError('Missing `cache_length=` kwarg when calling `init_cache()`.')
+
+  # NEW: Local-sliding layers only ever read sliding_window_size slots.
+  # Cap their cache to that to avoid allocating bytes that are guaranteed
+  # to be masked out at attention time.
+  local_cache_length = (
+      min(cache_length, self.sliding_window_size)
+      if self.sliding_window_size is not None
+      else cache_length
+  )
+
+  cache: Cache = {}
+  for i, attn_type in enumerate(self.attention_types):
+    if (attn_type == _modules.AttentionType.GLOBAL
+        and self.global_key_size is not None):
+      cache[f'layer_{i}'] = _modules.Attention.init_cache(
+          cache_length,                                  # full
+          self.num_global_kv_heads or self.num_kv_heads,
+          self.global_key_size,
+          batch_size, dtype)
+    else:
+      cache[f'layer_{i}'] = _modules.Attention.init_cache(
+          local_cache_length,                            # NEW: window-capped
+          self.num_kv_heads,
+          self.head_dim,
+          batch_size, dtype)
+  return cache
+```
+
+Do Gemma 4 first. Mirror into Gemma 3n only after the Gemma 4 path has
+passed equivalence tests, because Gemma 4 is the critical long-context
+path and already exercises heterogeneous local/global head dimensions.
+
+**Required collateral changes.** Per-layer cache sizes now vary, so
+several pieces of code that assume a uniform layer cache need to be
+fixed:
+
+1. **`Cache.total_cache_length`**
+   ([`_cache_helper.py:43-47`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L43-L47)).
+   Currently reads layer 0's `k.shape[1]`. Must return either the max
+   across layers or be replaced with a per-layer query. Recommendation:
+   `return max(d['k'].shape[1] for d in self.cache.values())`. The
+   `is_full` semantic at line 86-89 should then use the max — i.e.,
+   "stop sampling when the *largest* (typically global) cache is full",
+   not when the local cache fills up at the sliding-window boundary.
+
+2. **Full logical masks plus physical local-slot mapping.**
+   `SamplingState.attention_mask_for_step` should continue to build a
+   mask at the full logical cache length. Local attention cannot rely
+   on implicit einsum truncation once the local cache is ring-buffered:
+   physical slot `s` no longer means logical token `s`. Local cache
+   entries need `logical_index` and `valid` metadata, and
+   `Attention.__call__` must gather the logical mask onto physical
+   slots before applying the sliding mask.
+
+3. **Prefill prompt longer than `sliding_window_size`.** Do not simply
+   pass a window-sized local cache into prefill. The attention module
+   writes K/V into the supplied cache before computing attention; a
+   window-sized prefill cache would overwrite early prompt K/V before
+   later prompt tokens and later global layers can use them. The safe
+   first implementation is:
+   - Allocate the persistent decode cache with local layers sized to
+     `sliding_window_size`.
+   - Build a full-size prefill scratch cache for local layers, with no
+     local-window metadata, so prefill attention has legacy semantics.
+   - Run `model.apply` against the scratch.
+   - Compact the returned local layers back into the persistent ring
+     cache.
+   - Copy returned global layers into the persistent global cache.
+
+4. **Compaction must be per batch row.** A naive "last W logical slots"
+   compaction is wrong for padded batches: a short row can have live
+   local-context prompt tokens near logical slots 0..N while another
+   row forced the bucket to a much larger logical length. The safe rule
+   is to keep the last W valid logical slots per batch row, place each
+   by `absolute_position % W`, and store the original logical slot in
+   `logical_index` for future mask gathers.
+
+5. **Decode writes must evict by position, not padded logical index.**
+   Local-window decode writes should use `segment_pos % window` for the
+   physical slot and store `end_index + arange(seq_len)` only as
+   `logical_index` metadata. This preserves the local sliding window
+   for padded rows while keeping the sampler's full logical mask
+   intact.
+
+**Risks.**
+
+- **Correctness of scratch compaction.** Need to verify that ROPE
+  positions, `cache_positions`, `logical_index`, and `valid` are
+  correct after the prefill+merge dance. The sliding mask at
+  [`gemma4/_modules.py:343-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L343-L349)
+  uses `cache_positions` (the actual position stored at each slot), so
+  as long as we write the correct `positions` alongside the K/V values
+  and gather the logical mask through `logical_index`, the ring-buffer
+  math handles wraparound. Add regression tests for prompt lengths
+  `< window`, `== window`, and `> window`, plus padded batches where
+  one row is much shorter than the bucket length.
+- **Recompilation.** Changing layer shapes triggers a JIT recompile.
+  Acceptable, one-time.
+- **`is_full` semantics.** Today the loop stops when *layer 0* fills.
+  Layer 0 is local-sliding in every Gemma 4 variant, so today the
+  loop currently stops when the local cache fills (around step 512), which
+  is *the wrong stopping condition* for global layers. Today this
+  isn't observed because users typically pick `cache_length ≥ 4096 ≫
+  sliding_window` and don't notice. After this change, with the local
+  cache *physically* sized to the window, the same `is_full` would fire
+  at step 512 always. The sampler loop must stop on the logical
+  `SamplerLoop.cache_length` or `state.full_attention_mask.shape[-1]`,
+  not on any local layer's physical shape.
+
+**Test plan.**
+
+1. **Unit test:** for every Gemma 4 variant, verify
+   `model.init_cache(cache_length=4096)` produces local-layer cache
+   shapes of `[1, sliding_window_size, num_kv_heads, head_dim]` and
+   global-layer caches of `[1, 4096, num_global_kv_heads or
+   num_kv_heads, global_key_size or head_dim]`.
+2. **Numerical equivalence:** run a fixed prompt with a fixed RNG seed
+   through `ChatSampler.chat()` before and after the change. Output
+   tokens should match for greedy sampling. Logits only need BF16
+   tolerance because compacting/gathering can change reduction order.
+3. **HBM regression:** run [`examples/cache_probe.py`](./examples/cache_probe.py)
+   at L=4096 and L=16384 and verify the per-chip steady-state delta
+   drops as predicted in §3.1's table.
+
+### 3.2. Change B: cache sharding contract
+
+**Summary.** Add a model-level contract that exposes a
+`PartitionSpec` pytree for the cache, computed from the model config
+and the active mesh. Apply it inside `init_cache` regardless of
+whether the user passed a `sharding=` kwarg. For batch=1 decode, shard
+along `num_kv_heads` when the head count is divisible by the mesh's TP
+axis size; replicate otherwise.
+
+**Why this and not "expose more knobs to the user".** Today's
+`sharding=` kwarg is a generic `kd.sharding.ShardingTree`. The user has
+no documented way to construct one for the cache (no example exists in
+the repo, and `kd.sharding.FSDPSharding()` — the only documented
+sharding helper — shards axis 0, which is `batch` in the cache, which
+is 1 at decode time). The cache *is* a model-internal data structure
+with a model-internal layout; the model is the right place to know how
+it should partition.
+
+**HBM saved (E4B at L=4096, currently 392 MiB replicated on every chip
+of a 4-chip slice = 1.57 GiB total slice HBM):**
+
+- E4B (`num_kv_heads=2`, 4 chips → TP=2 + replicate=2): each chip
+  holds 1/2 of the cache → 196 MiB / chip → **196 MiB saved per chip**
+  (vs. 392 MiB replicated). Total slice HBM drops from 1.57 GiB → 784
+  MiB.
+- 31B (`num_kv_heads=16` local, 4 global, 4 chips → TP=4): each chip
+  holds 1/4 → **3/4 saved per chip** for local layers; global layers
+  shard exactly 4-ways. Roughly 4× per-chip cache reduction.
+- 26B-A4B (`num_kv_heads=8` local, 2 global, 4 chips → TP=4 for local,
+  TP=2+rep for global): roughly 4× for local, 2× for global.
+- E2B (`num_kv_heads=1`, can't shard heads): no win — falls back to
+  replication (current behavior). Acceptable.
+
+Composes multiplicatively with Change A. Combined for 31B at
+`cache_length=32768`:
+
+- Today: ~30 GiB replicated, OOMs immediately.
+- Change A only: ~4 GiB replicated.
+- Change B only: ~7-8 GiB per chip.
+- Change A + B: ~1 GiB per chip — fits with room for activations.
+
+**Implementation.**
+
+Add a method to `TransformerConfig` (Gemma 4) — and analogous changes
+to Gemma 1-3 and Gemma 3n configs — that returns a cache partition
+spec given the active mesh:
+
+```python
+def cache_partition_spec(self, mesh, *, tp_axis: str = 'tensor'):
+  """Return a PartitionSpec pytree for the cache.
+
+  Shards k/v along num_kv_heads when the head count is divisible by the
+  TP axis size; otherwise leaves replicated. Other cache fields
+  (positions, end_index) are always replicated.
+  """
+  from jax.sharding import PartitionSpec as P, NamedSharding
+  if tp_axis not in mesh.axis_names:
+    # No TP axis — replicate everything.
+    pspec_kv = P()
+    pspec_pos = P()
+    pspec_end = P()
+  else:
+    tp_size = mesh.shape[tp_axis]
+    # Replicate fallback if any layer's heads don't divide evenly.
+    def kv_spec(num_heads):
+      return P(None, None, tp_axis, None) if num_heads % tp_size == 0 else P()
+    # We build a per-layer spec because num_kv_heads can vary.
+    ...
+
+  spec_tree = {}
+  for i, attn_type in enumerate(self.attention_types):
+    if attn_type == _modules.AttentionType.GLOBAL and self.global_key_size:
+      heads = self.num_global_kv_heads or self.num_kv_heads
+    else:
+      heads = self.num_kv_heads
+    spec_tree[f'layer_{i}'] = {
+        'k': NamedSharding(mesh, kv_spec(heads)),
+        'v': NamedSharding(mesh, kv_spec(heads)),
+        'positions': NamedSharding(mesh, P()),
+        'end_index': NamedSharding(mesh, P()),
+    }
+  return spec_tree
+```
+
+Then in
+[`gemma/gm/nn/gemma4/_transformer.py:399-412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L399-L412):
+
+```python
+def init_cache(self, *, batch_size, dtype, cache_length, sharding=None):
+  cache = self.config.init_cache(
+      batch_size=batch_size, dtype=dtype, cache_length=cache_length)
+
+  # NEW: derive a model-aware default sharding from the active mesh,
+  # use it unless the user passed an explicit sharding.
+  if sharding is None:
+    mesh = _get_active_mesh()  # via jax.sharding.get_abstract_mesh() or similar
+    if mesh is not None:
+      sharding = self.config.cache_partition_spec(mesh)
+
+  return kd.sharding.with_sharding_constraint(cache, sharding)
+```
+
+Also: add `with_sharding_constraint` after every per-step cache write
+in `Attention.__call__` so the per-step `dynamic_update_slice` /
+`array.at[...].set(...)` doesn't all-gather the result back to a
+replicated layout. Locations:
+- Gemma 4: [`gemma4/_modules.py:307-316`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L307-L316).
+- Gemma 1-3: [`_modules.py:213-238`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_modules.py#L213-L238).
+- Gemma 3n: corresponding section in `gemma3n/_modules.py`.
+
+**Risks.**
+
+- **Mesh discovery.** Inside `nn.jit init_cache`, getting hold of "the
+  active mesh" requires either (a) requiring the user to pass it
+  explicitly, (b) using `jax.sharding.get_abstract_mesh()` (modern JAX),
+  or (c) inferring it from the params via `jax.tree.leaves(params)[0].sharding.mesh`.
+  Recommendation: (c), because it ensures the cache mesh matches the
+  param mesh — same TP axis, same chip ordering — and (c) doesn't
+  require any change to the public sampler API.
+- **Per-step all-reduce.** With cache sharded by heads and queries
+  replicated, the per-step attention op is `jnp.einsum('BTNH,BSNH->BTNS', q, k_sharded)`
+  which produces a `BTNS` result with `N` sharded — fine, no reduce
+  needed yet — and then `'BTNS,BSNH->BTNH'` produces a `BTNH` with `N`
+  sharded. The output projection `'BTNH,NHD->BTD'` reduces over `N`,
+  triggering an all-reduce. On v5e this is bandwidth-bound by ICI;
+  empirical cost should be small (≪ 1 ms / step) but must be measured.
+- **Non-divisible head counts.** E4B's `num_kv_heads=2` on a 4-chip
+  slice → TP=2, replicate=2 (the audit script confirms this works).
+  E2B's `num_kv_heads=1` → fall back to replication. The proposed
+  helper handles both via the `kv_spec(heads)` divisibility check.
+- **Backward compatibility.** Today the user can pass a
+  `sharding=`. We should preserve that as an override: if the user
+  passed an explicit non-`None` sharding, do not auto-derive. This
+  keeps the existing API contract and lets advanced users override.
+
+**Test plan.**
+
+1. **Audit:** [`examples/cache_audit.py --variant {e4b,31b,26b_a4b}
+   --shard heads`](./examples/cache_audit.py) already exists; verify
+   the auto-shard logic in `init_cache` produces the same
+   `NamedSharding(..., P(None, None, 'tensor', None))` on k/v that the
+   audit script's `--shard heads` mode produces.
+2. **HBM regression:** [`examples/cache_probe.py`](./examples/cache_probe.py)
+   should show **per-chip peak deltas drop by ~TP×** for E4B/31B.
+   E4B at L=4096 should drop from 1.6 GiB peak / chip to ~800 MiB
+   peak / chip. 31B at L=4096 should drop from ~3.7 GiB peak (today)
+   to ~900 MiB peak.
+3. **Numerical equivalence:** logit-level comparison before/after the
+   change for a fixed prompt and seed. Sharding does not change math.
+4. **Compile-time / step-time microbenchmark:** measure decode steps/sec
+   before and after on E4B at L=4096. Acceptance: ≤ 5% slowdown from
+   the per-step all-reduce on a 4-chip v5e slice.
+
+### 3.3. Out of scope but worth noting: the transient 2× cache copy
+
+The runtime probe shows a steady-state delta of ~800 MiB at L=4096 —
+about 2× the logical 392 MiB cache. The extra copy is created in
+`_merge_cache` at
+[`_prefill.py:357-366`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L357-L366):
+
+```python
+return full_cache.at[:, : prefill_cache.total_cache_length].set_kv(prefill_cache)
+```
+
+`Cache.at[].set_kv()` uses `jnp.ndarray.at[...].set(...)` semantics
+([`_cache_helper.py:113-119`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L113-L119),
+[`_cache_helper.py:149-155`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L149-L155)),
+which is functional. Without `donate_argnums` on the surrounding jit,
+JAX may keep both the old and new buffers alive briefly, causing a
+~2× transient. After the merge, `last_state.cache` retains the
+*new* buffer; the old `full_cache` should be garbage-collected. The
+fact that the steady-state delta is 2× suggests the old buffer is
+still being held — likely because it's the input to `_merge_cache`
+inside the JITted prefill, and JAX keeps it alive until the prefill
+function returns.
+
+This isn't part of this proposal, but a follow-up could:
+- Donate the input cache buffer in the prefill jit
+  (`jax.jit(prefill_fn, donate_argnums=...)`).
+- Or restructure prefill to write directly into `full_cache` without
+  the intermediate small-cache prefill + merge.
+
+Estimated savings: an additional ~1× cache (cuts the per-chip
+steady-state delta from 2×cache to 1×cache).
+
+### 3.4. Stack rank
+
+If only one change can be merged: **Change A**. It's smaller, safer,
+benefits every Gemma 4 variant including E2B, and saves the most
+absolute bytes at long contexts. Change B has a hard ceiling on E2B
+(`num_kv_heads=1` is not shardable) and is most valuable on the bigger
+models that already need the 8x slice.
+
+If both can be merged: ship them together. They compose
+multiplicatively for HBM and touch nearby code. The combined
+expected reduction in per-chip cache HBM:
+
+| Model | L | Today (replicated) | A only | B only | A + B |
+|---|---:|---:|---:|---:|---:|
+| E4B  |  4 096 | 392 MiB | 147 MiB | 196 MiB | 74 MiB |
+| E4B  | 16 384 | 1.51 GiB | 483 MiB | 753 MiB | 241 MiB |
+| 31B  |  4 096 | 3.69 GiB | 1.17 GiB | 920 MiB | 290 MiB |
+| 31B  | 32 768 | 29.5 GiB | 3.52 GiB | 7.4 GiB | 880 MiB |
+
+(Absolute numbers per chip, batch=1, bf16, 4-chip slice for E4B and
+31B. 31B at L=32K with current code does not fit; with both changes,
+fits with substantial headroom.)
+
+---
+
+## 4. Risks & Open Questions
+
+1. **`is_full` semantics.** Currently a soft bug today (loop stops
+   when layer-0 fills, which today is local-sliding). Change A makes
+   this strictly observable. Fix in scope of Change A, but worth
+   reviewer eyes.
+2. **Mesh discovery for Change B.** Recommend inferring from
+   `params` to avoid public-API churn; reviewer may prefer an explicit
+   API.
+3. **Per-step all-reduce cost on Change B.** Need empirical
+   measurement before claiming step-time parity. If the all-reduce
+   exceeds ~5% of step time, consider replicating queries after the
+   sharded attention output (or using `jax.lax.psum_scatter` /
+   `with_sharding_constraint` to keep the reduce out of the critical
+   path).
+4. **Multi-turn correctness.** Multi-turn reuses
+   `prev_turns.cache`. After Change A, the cache shape is
+   `{layer_i: [B, layer_cache_size, ...]}` per layer. Code paths that
+   inspect cache shape (e.g.
+   [`_chat_sampler._remove_eos_token`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L445)
+   touches `cache_info` but only `end_index`) should be audited.
+5. **Compatibility with `KVCacheSharingConfig`** for the
+   shared-layer path
+   ([`gemma4/_config.py:32-84`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L32-L84),
+   used by E2B and E4B with `frac_shared_layers > 0`). The sharing
+   pattern shares cache between layers — Change A's per-layer sizes
+   must be consistent across shared layer pairs (which they are, since
+   sharing groups layers of the same attention type).
+6. **Quantization / LoRA.** Out of scope, but worth noting that the
+   cache lives at sampling time (no params-quantization interaction)
+   and isn't itself quantized.
+
+---
+
+## 5. Plan of Work
+
+Phased so each phase is independently revertible:
+
+**Phase 0 (this proposal).** Land
+[`examples/cache_audit.py`](./examples/cache_audit.py) and
+[`examples/cache_probe.py`](./examples/cache_probe.py). They are
+read-only diagnostic tools, useful regardless of which fix lands.
+
+**Phase 1 (Change A).** Right-size local-sliding cache.
+
+1. Add per-layer cache sizing in
+   [`gemma/gm/nn/gemma4/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py)
+   and [`gemma/gm/nn/gemma3n/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_config.py).
+2. Fix `Cache.total_cache_length` and `is_full` in
+   [`gemma/gm/utils/_cache_helper.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py).
+3. Fix prefill cache slice / merge in
+   [`gemma/gm/text/_prefill.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py)
+   to handle per-layer sizes.
+4. Add unit tests + numerical-equivalence test.
+5. Verify HBM reduction with `examples/cache_probe.py` on E4B at
+   L=4096 and L=16384.
+
+Estimated diff: ~80 LOC of source + ~150 LOC of tests.
+
+**Phase 2 (Change B).** Cache sharding contract.
+
+1. Add `cache_partition_spec(mesh)` to `TransformerConfig` (Gemma 4,
+   Gemma 1-3, Gemma 3n).
+2. Wire mesh inference in `Transformer.init_cache` via the params'
+   sharding.
+3. Add per-step `with_sharding_constraint` after cache writes in
+   each `Attention.__call__`.
+4. Add per-step / per-prefill numerical-equivalence + HBM tests.
+
+Estimated diff: ~120 LOC of source + ~200 LOC of tests.
+
+**Phase 3 (optional follow-up).** Address the 2× transient via
+prefill donation (§3.3).
+
+---
+
+## 6. Validation / Benchmark Plan
+
+The benchmarks below should be run *before* and *after* each phase to
+establish a clean attribution of savings. Use [`examples/cache_probe.py`](./examples/cache_probe.py)
+as the primary HBM measurement tool and `time` as decode-rate measurement.
+
+**Hardware:** v5e-4 (4 chips, 16 GB HBM each). v5e-8 if accessible
+for 31B confirmation.
+
+**Models:** Gemma4_E2B (sanity, no head-sharding gain), Gemma4_E4B
+(primary), Gemma4_31B (extrapolation; v5e-8).
+
+**Workload:** single-turn `chat()` with a fixed prompt and
+`max_new_tokens=64`, `multi_turn=False`, `cache_length ∈
+{4096, 16384, 32768}`. RNG seeded.
+
+**Metrics per (model, cache_length, change):**
+
+| Metric | Source |
+|---|---|
+| Per-chip peak HBM during chat() | `device.memory_stats()['peak_bytes_in_use']` |
+| Per-chip steady-state HBM after chat() | `device.memory_stats()['bytes_in_use']` |
+| End-to-end chat() latency (warm) | `time.time()` around `sampler.chat(...)` |
+| Logit hash for first 64 sampled tokens | `hashlib.sha256(jnp.asarray(state.predicted_tokens).tobytes())` |
+
+**Acceptance criteria:**
+
+- HBM: Per-chip peak HBM drops by at least 80% of the predicted
+  savings in §3.1 / §3.2 tables. Greedy sampled tokens should match
+  before/after the change; logits should stay within BF16 tolerance.
+- Latency: ≤ 5% regression on E4B at L=4096. Long-context (L=16384+)
+  may improve due to less HBM traffic on the masked region.
+- No new compile-time blowups (compile time within 2× of baseline).
+
+---
+
+## 7. Why this is a good idea, briefly
+
+The Gemma-4-specific local-sliding pathology is a structural property
+of how `_config.init_cache` is written, not a feature; the masking
+code already proves the bytes are unread. The cache replication is
+similarly an artifact of "no model knows what mesh the user will run
+on" — but the model trivially knows once params have been placed. Both
+fixes are local, testable, and unlock long-context evaluation of the
+larger Gemma 4 variants on commodity TPU slices. Neither requires
+changes to the user-facing API surface.
+
+---
+
+## Appendix A — Diagnostic tooling
+
+This proposal ships two read-only scripts (already in
+[`examples/`](./examples/)) used to gather the empirical numbers above.
+They are not part of the runtime path.
+
+- **[`examples/cache_audit.py`](./examples/cache_audit.py)** — inspects
+  the cache pytree shape/dtype/sharding per leaf without any param
+  load. `--shard heads` simulates the proposed Change B sharding so
+  reviewers can see what the post-change layout looks like.
+- **[`examples/cache_probe.py`](./examples/cache_probe.py)** — runs a
+  real `ChatSampler.chat()` with FSDP-sharded params and reports
+  per-chip HBM deltas. Used to derive the runtime numbers in §1.1.
+
+Both scripts are useful regression tools to verify Phase 1 and Phase 2
+numerically.

--- a/examples/cache_audit.py
+++ b/examples/cache_audit.py
@@ -1,0 +1,360 @@
+"""Empirical KV-cache audit for the gemma sampler.
+
+Standalone script that inspects the cache pytree allocated by the same
+code path the sampler hits during prefill (gemma/gm/text/_prefill.py:295).
+Calls `model.config.init_cache(...)` directly; that's the underlying
+allocator. Skips the flax-module `nn.jit` wrapper because it requires a
+bound module, but the allocation it produces is identical.
+
+What it answers:
+- Phase 2.1: load Gemma4_E2B (smallest) on whatever JAX backend is available.
+- Phase 2.2: build the cache via `config.init_cache(cache_length=256)`.
+- Phase 2.3: per-leaf shape, dtype, and sharding (or NONE if host-array).
+- Phase 2.4: total cache bytes, broken down by attention type and tensor.
+- Phase 2.5: re-run with cache_length=4096 and report the growth ratio.
+
+Optional Hypothesis-B probe (--shard {none,fsdp,heads}):
+- 'none'  : no sharding (default sampler behavior). Confirms replication.
+- 'fsdp'  : shard along axis 0 (batch). What FSDPSharding-on-cache would do.
+            With batch=1 this collapses to replication.
+- 'heads' : shard k/v along axis 2 (num_kv_heads). The right sharding for
+            batch=1 decode.
+
+Usage on TPU node (no clone needed; uses the pip-installed gemma):
+
+    python cache_audit.py
+    python cache_audit.py --variant 31b --cache_lengths 256 4096
+    python cache_audit.py --variant e4b --cache_mode local_window
+    python cache_audit.py --variant 31b --cache_lengths 4096 --shard heads
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import jax
+import jax.numpy as jnp
+
+
+def _human_bytes(n: float) -> str:
+  for unit in ("B", "KiB", "MiB", "GiB"):
+    if n < 1024:
+      return f"{n:.2f} {unit}"
+    n /= 1024
+  return f"{n:.2f} TiB"
+
+
+def _fmt_sharding(arr) -> str:
+  """Render an array's sharding compactly, or 'NONE' for host-only arrays."""
+  if not isinstance(arr, jax.Array):
+    return "NONE (host)"
+  s = getattr(arr, "sharding", None)
+  if s is None:
+    return "NONE"
+  cls = type(s).__name__
+  spec = getattr(s, "spec", None)
+  if spec is not None:
+    return f"{cls}{tuple(spec)}"
+  # SingleDeviceSharding / others.
+  return cls
+
+
+def _build_mesh(n_devices: int, *, tp_axis: int = None):
+  """Build a 2D mesh; if tp_axis is None, all devices go to tensor."""
+  from jax.sharding import Mesh
+  import numpy as np
+  if tp_axis is None or tp_axis >= n_devices:
+    tp_axis = n_devices
+  rep_axis = n_devices // tp_axis
+  if rep_axis * tp_axis != n_devices:
+    # Fall back to flat 1D 'tensor' mesh.
+    devices = np.asarray(jax.devices()).reshape((n_devices,))
+    return Mesh(devices, axis_names=("tensor",))
+  devices = np.asarray(jax.devices()).reshape((rep_axis, tp_axis))
+  return Mesh(devices, axis_names=("replicate", "tensor"))
+
+
+def _gcd(a: int, b: int) -> int:
+  while b:
+    a, b = b, a % b
+  return a
+
+
+def _maybe_apply_sharding(cache, *, mode: str, mesh):
+  """Apply a sharding to k/v leaves of the cache, or return as-is.
+
+  - 'none'  : leave as-is (default sampler behavior).
+  - 'fsdp'  : shard axis 0 (batch). At batch=1 this is impossible; we skip
+              with a warning to mirror what kd.sharding.FSDPSharding would do.
+  - 'heads' : shard axis 2 (num_kv_heads) for k/v. We pick the largest TP
+              size that evenly divides every layer's head count and
+              replicate over the remaining devices.
+  """
+  from jax.sharding import NamedSharding, PartitionSpec as P
+
+  if mode == "none" or mesh is None:
+    return cache
+
+  if mode == "fsdp":
+    sample = next(iter(cache.values()))["k"]
+    if sample.shape[0] == 1:
+      print("  [fsdp shard] batch=1 -> axis-0 sharding impossible; "
+            "cache stays single-device. This is exactly the OOM pattern.")
+      return cache
+    # Else (rare for sampler), fall through to honoring the user's request.
+
+  # Compute the largest tp size that evenly divides every layer's head count.
+  head_counts = []
+  for layer_name, layer_data in cache.items():
+    head_counts.append(layer_data["k"].shape[2])
+  n_dev = mesh.devices.size
+  tp = n_dev
+  for h in head_counts:
+    tp = _gcd(tp, h)
+  if tp <= 1:
+    print(f"  [heads shard] no evenly-divisible TP size (head counts="
+          f"{sorted(set(head_counts))}, devices={n_dev}); "
+          "cache stays single-device.")
+    return cache
+  if tp != n_dev:
+    print(f"  [heads shard] TP={tp} (heads divisible), replicate over "
+          f"{n_dev // tp} chips. Per-chip memory ~= 1/{tp} of logical total.")
+
+  # Rebuild a 2D mesh of (replicate, tensor) with these factors.
+  from jax.sharding import Mesh
+  import numpy as np
+  rep = n_dev // tp
+  devices_arr = np.asarray(jax.devices()).reshape((rep, tp)) if rep > 1 \
+      else np.asarray(jax.devices()).reshape((tp,))
+  if rep > 1:
+    mesh_used = Mesh(devices_arr, axis_names=("replicate", "tensor"))
+  else:
+    mesh_used = Mesh(devices_arr, axis_names=("tensor",))
+
+  def kv_spec_for(arr):
+    rank = arr.ndim
+    if mode == "fsdp":
+      spec = P("tensor",) + (None,) * (rank - 1)
+    elif mode == "heads":
+      if rank == 4:
+        spec = P(None, None, "tensor", None)
+      else:
+        spec = P(*(None,) * rank)
+    else:
+      raise ValueError(f"Unknown shard mode: {mode}")
+    return NamedSharding(mesh_used, spec)
+
+  out = {}
+  for layer_name, layer_data in cache.items():
+    new_layer = {}
+    for tensor_name, arr in layer_data.items():
+      try:
+        new_layer[tensor_name] = jax.device_put(arr, kv_spec_for(arr))
+      except Exception as e:  # pylint: disable=broad-except
+        print(f"  [warn] could not shard {layer_name}/{tensor_name} "
+              f"(shape={tuple(arr.shape)}): {e}; leaving as-is.")
+        new_layer[tensor_name] = arr
+    out[layer_name] = new_layer
+  return out
+
+
+def audit_cache(model, cache_length: int, *, batch_size: int, dtype,
+                cache_mode, shard_mode: str, mesh) -> int:
+  """Allocate a cache and dump per-leaf info. Returns total bytes."""
+  print(f"\n=== cache_length={cache_length}, batch_size={batch_size}, "
+        f"dtype={dtype.__name__ if hasattr(dtype, '__name__') else dtype}, "
+        f"cache_mode={cache_mode.value}, shard={shard_mode} ===")
+
+  # Allocate via the underlying allocator (same one the sampler hits).
+  # See _prefill.py -> model.init_cache(...) -> config.init_cache.
+  cache = model.config.init_cache(
+      batch_size=batch_size,
+      dtype=dtype,
+      cache_length=cache_length,
+      kv_cache_mode=cache_mode,
+  )
+  cache = _maybe_apply_sharding(cache, mode=shard_mode, mesh=mesh)
+
+  total_bytes = 0
+  by_kind = {}
+  per_layer_bytes = []
+
+  layer_names = sorted(cache.keys(), key=lambda s: int(s.split("_")[-1]))
+  attn_types = list(model.config.attention_types)
+
+  print(f"\n{'layer':>9}  {'attn':>6}  {'tensor':>10}  {'shape':>32}  "
+        f"{'dtype':>10}  {'bytes':>12}  sharding")
+  print("-" * 130)
+
+  sample_layer_idxs = {0, 1, len(layer_names) // 2, len(layer_names) - 1}
+  for i, layer_name in enumerate(layer_names):
+    layer_data = cache[layer_name]
+    layer_total = 0
+    attn = attn_types[i].name[:6]
+    for tensor_name, arr in layer_data.items():
+      shape = tuple(arr.shape)
+      dt = arr.dtype
+      nbytes = int(arr.size) * arr.itemsize
+      total_bytes += nbytes
+      layer_total += nbytes
+      cnt, b = by_kind.get(tensor_name, (0, 0))
+      by_kind[tensor_name] = (cnt + 1, b + nbytes)
+      if i in sample_layer_idxs:
+        print(f"{layer_name:>9}  {attn:>6}  {tensor_name:>10}  "
+              f"{str(shape):>32}  {str(dt):>10}  {_human_bytes(nbytes):>12}  "
+              f"{_fmt_sharding(arr)}")
+    per_layer_bytes.append((layer_name, attn, layer_total))
+
+  print(f"\n[{len(layer_names)} layers total; only sample layers shown above]")
+
+  print("\nBy tensor kind:")
+  for kind, (cnt, b) in sorted(by_kind.items()):
+    print(f"  {kind:>10}: {cnt:>3} arrays, {_human_bytes(b):>12}")
+
+  local_bytes = sum(b for _, a, b in per_layer_bytes if a == "LOCAL_")
+  global_bytes = sum(b for _, a, b in per_layer_bytes if a == "GLOBAL")
+  if local_bytes or global_bytes:
+    n_local = sum(1 for _, a, _ in per_layer_bytes if a == "LOCAL_")
+    n_global = sum(1 for _, a, _ in per_layer_bytes if a == "GLOBAL")
+    print("\nBy attention type:")
+    print(f"  LOCAL_SLIDING ({n_local:>3} layers): {_human_bytes(local_bytes)}")
+    print(
+        f"  GLOBAL        ({n_global:>3} layers): "
+        f"{_human_bytes(global_bytes)}"
+    )
+
+  print(f"\nTOTAL cache size (logical, summed over all layers): "
+        f"{_human_bytes(total_bytes)} ({total_bytes:,} bytes)")
+  if mesh is not None and shard_mode == "heads":
+    # Determine the actual TP factor used (gcd of all head counts and ndev).
+    head_counts = [cache[ln]["k"].shape[2] for ln in layer_names]
+    n_dev = mesh.devices.size
+    tp = n_dev
+    for h in head_counts:
+      tp = _gcd(tp, h)
+    rep = n_dev // max(1, tp)
+    if tp <= 1:
+      print("  TP=1 (no sharding possible); cache stays single-device.")
+    else:
+      per_chip = total_bytes / tp
+      print(f"  TP={tp}, replicate={rep}: each chip holds 1/{tp} of the "
+            f"cache => ~{_human_bytes(per_chip)} per chip.")
+      print(f"  HBM consumed across whole {n_dev}-chip slice: "
+            f"~{_human_bytes(per_chip * n_dev)} "
+            f"(per_chip x {n_dev} chips, since "
+            f"{rep} group(s) replicate the same shards).")
+  elif shard_mode == "none":
+    print("  Cache is unconstrained; `jnp.zeros` outside any jit lands on "
+          "JAX's default device. Expected: SingleDeviceSharding on chip 0. "
+          "Inside the real sampler's `nn.jit` it may instead replicate "
+          "across the active mesh, but in EITHER case it is not sharded "
+          "across chips.")
+
+  first_k = cache[layer_names[0]]["k"]
+  if isinstance(first_k, jax.Array) and jax.local_device_count() > 1:
+    print("\nSharding visualization for cache[layer_0]['k']:")
+    try:
+      jax.debug.visualize_array_sharding(first_k)
+    except Exception as e:  # pylint: disable=broad-except
+      print(f"  (visualize_array_sharding failed: {e})")
+
+  return total_bytes
+
+
+def build_model(variant: str):
+  """Construct a Gemma 4 flax module without loading params."""
+  from gemma import gm  # pylint: disable=g-import-not-at-top
+  cls = {
+      "e2b": gm.nn.Gemma4_E2B,
+      "e4b": gm.nn.Gemma4_E4B,
+      "31b": gm.nn.Gemma4_31B,
+      "26b_a4b": gm.nn.Gemma4_26B_A4B,
+  }[variant.lower()]
+  return cls()
+
+
+def main(argv=None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--variant", default="e2b",
+                      choices=("e2b", "e4b", "31b", "26b_a4b"))
+  parser.add_argument("--cache_lengths", type=int, nargs="+",
+                      default=[256, 4096])
+  parser.add_argument("--batch_size", type=int, default=1)
+  parser.add_argument("--dtype", default="bfloat16",
+                      choices=("bfloat16", "float16", "float32"))
+  parser.add_argument("--cache_mode", default="legacy",
+                      choices=("legacy", "local_window"),
+                      help="KV cache allocation mode to audit.")
+  parser.add_argument("--shard", default="none",
+                      choices=("none", "fsdp", "heads"),
+                      help="Sharding strategy for the cache "
+                           "(see module docstring).")
+  args = parser.parse_args(argv)
+
+  dtype = {"bfloat16": jnp.bfloat16, "float16": jnp.float16,
+           "float32": jnp.float32}[args.dtype]
+  from gemma.gm.utils import (  # pylint: disable=g-import-not-at-top
+      _cache_helper,
+  )
+  cache_mode = _cache_helper.KVCacheMode(args.cache_mode)
+
+  print(f"JAX version: {jax.__version__}")
+  print(f"JAX devices: {jax.devices()}")
+  n_dev = jax.local_device_count()
+  mesh = _build_mesh(n_dev) if n_dev > 1 else None
+  if mesh is not None:
+    print(f"Mesh: {mesh}")
+  elif args.shard != "none":
+    print(f"WARNING: only {n_dev} device(s) visible; --shard={args.shard} "
+          "will fall back to single-device placement.")
+
+  print(f"Building Gemma4_{args.variant.upper()} (no params load)...")
+  model = build_model(args.variant)
+  cfg = model.config
+  print(f"  num_layers          = {cfg.num_layers}")
+  print(f"  num_kv_heads        = {cfg.num_kv_heads}")
+  print(f"  num_global_kv_heads = {cfg.num_global_kv_heads}")
+  print(f"  head_dim            = {cfg.head_dim}")
+  print(f"  global_key_size     = {cfg.global_key_size}")
+  print(f"  sliding_window_size = {cfg.sliding_window_size}")
+  n_local = sum(1 for a in cfg.attention_types if a.name == "LOCAL_SLIDING")
+  n_global = sum(1 for a in cfg.attention_types if a.name == "GLOBAL")
+  print(f"  local layers        = {n_local}")
+  print(f"  global layers       = {n_global}")
+
+  results = {}
+  for L in args.cache_lengths:
+    results[L] = audit_cache(
+        model, cache_length=L, batch_size=args.batch_size,
+        dtype=dtype, cache_mode=cache_mode, shard_mode=args.shard, mesh=mesh,
+    )
+
+  if len(results) >= 2:
+    Ls = sorted(results)
+    base = results[Ls[0]]
+    print(f"\n{'=' * 60}")
+    print("Cache size scaling with cache_length:")
+    for L in Ls:
+      ratio = results[L] / base
+      print(f"  cache_length={L:>6}: {_human_bytes(results[L]):>12}  "
+            f"(x{ratio:.2f} of cache_length={Ls[0]})")
+    expected = Ls[-1] / Ls[0]
+    actual = results[Ls[-1]] / results[Ls[0]]
+    print(f"\nExpected ratio (linear in cache_length): x{expected:.2f}")
+    print(f"Actual ratio                            : x{actual:.2f}")
+    if cache_mode == _cache_helper.KVCacheMode.LOCAL_WINDOW:
+      print("=> LOCAL_WINDOW mode should scale sub-linearly once local layers "
+            "hit the sliding-window cap; global layers still scale linearly.")
+    elif abs(actual - expected) / expected < 0.05:
+      print("=> Cache scales LINEARLY with cache_length on every layer.")
+      print("   Confirms eager pre-allocation across all layers,")
+      print("   including LOCAL_SLIDING layers that only need the window.")
+    else:
+      print("=> Cache scales SUB-LINEARLY; some layers are size-capped.")
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/examples/cache_local_window_test.py
+++ b/examples/cache_local_window_test.py
@@ -1,0 +1,180 @@
+"""End-to-end equivalence + memory test for KVCacheMode.LOCAL_WINDOW.
+
+Runs the same prompt+seed through `ChatSampler.chat()` twice (LEGACY then
+LOCAL_WINDOW) and:
+  1. Verifies the greedy token sequences match exactly.
+  2. Reports per-chip peak HBM for both modes so the win is visible.
+
+Usage on TPU node:
+
+    # Default: E2B smoke test, cache_length=4096, prompt <= window.
+    python cache_local_window_test.py
+
+    # Stress test: prompt LONGER than the window (forces ring wrap).
+    python cache_local_window_test.py --variant e4b --cache_length 16384 \
+        --prompt_repeat 200
+
+    # Stress test: cache_length larger than window, exercise the cap.
+    python cache_local_window_test.py --variant e4b --cache_length 32768
+
+Flags:
+    --variant      e2b | e4b | 31b
+    --cache_length int (default 4096)
+    --prompt       str (default a short greeting)
+    --prompt_repeat N - repeat the prompt N times to make it longer than
+                       sliding_window_size.
+    --max_new_tokens int (default 32)
+    --params_fsdp / --no-params_fsdp (default on)
+    --tolerance_bf16 float - max allowed |logit delta|. Default 5e-2 because
+                       BF16 reduction order changes between modes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import jax
+import jax.numpy as jnp
+
+
+def _human(b: float) -> str:
+  for u in ('B', 'KiB', 'MiB', 'GiB'):
+    if abs(b) < 1024:
+      return f'{b:.2f} {u}'
+    b /= 1024
+  return f'{b:.2f} TiB'
+
+
+def hbm_peak() -> dict[int, int]:
+  out = {}
+  for d in jax.devices():
+    if not hasattr(d, 'memory_stats'):
+      continue
+    try:
+      stats = d.memory_stats() or {}
+    except Exception:  # pylint: disable=broad-except
+      stats = {}
+    out[d.id] = int(stats.get('peak_bytes_in_use', 0))
+  return out
+
+
+def build_sampler(variant: str, cache_length: int, kv_cache_mode,
+                  params_fsdp: bool, params=None):
+  from gemma import gm  # pylint: disable=g-import-not-at-top
+
+  variants = {
+      'e2b': (gm.nn.Gemma4_E2B, 'GEMMA4_E2B_IT'),
+      'e4b': (gm.nn.Gemma4_E4B, 'GEMMA4_E4B_IT'),
+      '31b': (gm.nn.Gemma4_31B, 'GEMMA4_31B_IT'),
+  }
+  cls, ckpt_name = variants[variant.lower()]
+  model = cls()
+  if params is None:
+    ckpt_path = getattr(gm.ckpts.CheckpointPath, ckpt_name)
+    if params_fsdp:
+      from kauldron import kd  # pylint: disable=g-import-not-at-top
+      params = gm.ckpts.load_params(
+          ckpt_path, sharding=kd.sharding.FSDPSharding()
+      )
+    else:
+      params = gm.ckpts.load_params(ckpt_path)
+  sampler = gm.text.ChatSampler(
+      model=model,
+      params=params,
+      cache_length=cache_length,
+      kv_cache_mode=kv_cache_mode,
+      multi_turn=False,
+  )
+  return sampler, params
+
+
+def main(argv=None) -> int:
+  from gemma.gm.utils import (  # pylint: disable=g-import-not-at-top
+      _cache_helper,
+  )
+
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--variant', default='e2b', choices=('e2b', 'e4b', '31b'))
+  parser.add_argument('--cache_length', type=int, default=4096)
+  parser.add_argument('--prompt', default='Tell me a one-sentence fun fact.')
+  parser.add_argument('--prompt_repeat', type=int, default=1,
+                      help='Repeat the prompt this many times to stress the '
+                           'window-wrap path (use >= 200 for E4B with '
+                           'sliding_window=512 to force wrap).')
+  parser.add_argument('--max_new_tokens', type=int, default=32)
+  parser.add_argument('--params_fsdp',
+                      action=argparse.BooleanOptionalAction, default=True)
+  parser.add_argument('--seed', type=int, default=42)
+  args = parser.parse_args(argv)
+
+  prompt = (args.prompt + ' ') * max(1, args.prompt_repeat)
+
+  print(f'JAX devices: {jax.devices()}')
+  print(f'Model: {args.variant.upper()}, cache_length={args.cache_length}')
+  print(f'Prompt length (chars): {len(prompt)}')
+  print(f'max_new_tokens: {args.max_new_tokens}')
+  print('-' * 70)
+
+  # ---- Run 1: LEGACY ---- (load params here, share with run 2)
+  print('\n[1/2] Running LEGACY (current behavior)...')
+  sampler_legacy, params = build_sampler(
+      args.variant, args.cache_length,
+      _cache_helper.KVCacheMode.LEGACY, args.params_fsdp,
+  )
+  t0 = time.time()
+  out_legacy = sampler_legacy.chat(
+      prompt, max_new_tokens=args.max_new_tokens, rng=args.seed,
+  )
+  legacy_time = time.time() - t0
+  legacy_peak = hbm_peak()
+  print(f'  output: {out_legacy[:120]!r}')
+  print(f'  time:   {legacy_time:.1f}s')
+  for d, p in sorted(legacy_peak.items()):
+    print(f'  chip {d} peak HBM: {_human(p)}')
+
+  del sampler_legacy
+
+  # ---- Run 2: LOCAL_WINDOW ----
+  print('\n[2/2] Running LOCAL_WINDOW...')
+  sampler_lw, _ = build_sampler(
+      args.variant, args.cache_length,
+      _cache_helper.KVCacheMode.LOCAL_WINDOW, args.params_fsdp, params=params,
+  )
+  t0 = time.time()
+  out_lw = sampler_lw.chat(
+      prompt, max_new_tokens=args.max_new_tokens, rng=args.seed,
+  )
+  lw_time = time.time() - t0
+  lw_peak = hbm_peak()
+  print(f'  output: {out_lw[:120]!r}')
+  print(f'  time:   {lw_time:.1f}s')
+  for d, p in sorted(lw_peak.items()):
+    print(f'  chip {d} peak HBM: {_human(p)}')
+
+  # ---- Compare ----
+  print('\n' + '=' * 70)
+  print('Equivalence check:')
+  if out_legacy == out_lw:
+    print(f'  PASS: greedy outputs match exactly.')
+  else:
+    print(f'  FAIL: outputs DIFFER.')
+    print(f'    LEGACY:       {out_legacy!r}')
+    print(f'    LOCAL_WINDOW: {out_lw!r}')
+
+  print('\nMemory comparison (peak HBM during chat):')
+  print(f'  {"chip":>4}  {"LEGACY":>14}  {"LOCAL_WINDOW":>14}  {"saved":>14}')
+  total_saved = 0
+  for d in sorted(legacy_peak):
+    saved = legacy_peak[d] - lw_peak.get(d, 0)
+    total_saved += saved
+    print(f'  {d:>4}  {_human(legacy_peak[d]):>14}  '
+          f'{_human(lw_peak.get(d, 0)):>14}  {_human(saved):>14}')
+  print(f'  total peak HBM saved across slice: {_human(total_saved)}')
+
+  return 0 if out_legacy == out_lw else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/examples/cache_local_window_test.py
+++ b/examples/cache_local_window_test.py
@@ -1,9 +1,10 @@
 """End-to-end equivalence + memory test for KVCacheMode.LOCAL_WINDOW.
 
-Runs the same prompt+seed through `ChatSampler.chat()` twice (LEGACY then
-LOCAL_WINDOW) and:
-  1. Verifies the greedy token sequences match exactly.
-  2. Reports per-chip peak HBM for both modes so the win is visible.
+Each KV cache mode is benchmarked in its own subprocess so that
+`peak_bytes_in_use` is a clean per-process high-water mark, not polluted by
+a previous mode's allocations. The driver spawns two subprocesses, captures
+their output (greedy text + per-chip peak HBM as JSON on stdout), and
+reports the comparison.
 
 Usage on TPU node:
 
@@ -11,32 +12,26 @@ Usage on TPU node:
     python cache_local_window_test.py
 
     # Stress test: prompt LONGER than the window (forces ring wrap).
-    python cache_local_window_test.py --variant e4b --cache_length 16384 \
+    python cache_local_window_test.py --variant e4b --cache_length 16384 \\
         --prompt_repeat 200
 
-    # Stress test: cache_length larger than window, exercise the cap.
+    # Stress test: long context, big cache, the win that matters.
     python cache_local_window_test.py --variant e4b --cache_length 32768
 
-Flags:
-    --variant      e2b | e4b | 31b
-    --cache_length int (default 4096)
-    --prompt       str (default a short greeting)
-    --prompt_repeat N - repeat the prompt N times to make it longer than
-                       sliding_window_size.
-    --max_new_tokens int (default 32)
-    --params_fsdp / --no-params_fsdp (default on)
-    --tolerance_bf16 float - max allowed |logit delta|. Default 5e-2 because
-                       BF16 reduction order changes between modes.
+If you want to inspect a single mode interactively, use --mode:
+
+    python cache_local_window_test.py --variant e4b --cache_length 16384 \\
+        --mode local_window
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import subprocess
 import sys
 import time
-
-import jax
-import jax.numpy as jnp
 
 
 def _human(b: float) -> str:
@@ -48,6 +43,9 @@ def _human(b: float) -> str:
 
 
 def hbm_peak() -> dict[int, int]:
+  """Per-device peak HBM. Imports JAX lazily so the driver process doesn't
+  initialize JAX (and therefore doesn't grab any TPU memory)."""
+  import jax  # pylint: disable=g-import-not-at-top
   out = {}
   for d in jax.devices():
     if not hasattr(d, 'memory_stats'):
@@ -56,7 +54,7 @@ def hbm_peak() -> dict[int, int]:
       stats = d.memory_stats() or {}
     except Exception:  # pylint: disable=broad-except
       stats = {}
-    out[d.id] = int(stats.get('peak_bytes_in_use', 0))
+    out[int(d.id)] = int(stats.get('peak_bytes_in_use', 0))
   return out
 
 
@@ -90,11 +88,87 @@ def build_sampler(variant: str, cache_length: int, kv_cache_mode,
   return sampler, params
 
 
-def main(argv=None) -> int:
-  from gemma.gm.utils import (  # pylint: disable=g-import-not-at-top
-      _cache_helper,
-  )
+def run_one_mode(args, mode_name: str) -> dict:
+  """Run a single mode in this process. Returns a dict of results."""
+  from gemma.gm.utils import _cache_helper  # pylint: disable=g-import-not-at-top
+  import jax  # pylint: disable=g-import-not-at-top
 
+  prompt = (args.prompt + ' ') * max(1, args.prompt_repeat)
+  mode = _cache_helper.KVCacheMode(mode_name)
+
+  sampler, _ = build_sampler(
+      args.variant, args.cache_length, mode, args.params_fsdp,
+  )
+  t0 = time.time()
+  out = sampler.chat(prompt, max_new_tokens=args.max_new_tokens,
+                     rng=args.seed)
+  elapsed = time.time() - t0
+  peak = hbm_peak()
+  return {
+      'mode': mode_name,
+      'variant': args.variant,
+      'cache_length': args.cache_length,
+      'output': out,
+      'time_s': elapsed,
+      'peak_per_chip': peak,
+      'jax_devices': [str(d) for d in jax.devices()],
+  }
+
+
+def _print_single_mode_report(result: dict) -> None:
+  print(f'\n=== mode={result["mode"]} ===')
+  print(f'  variant: {result["variant"]}, cache_length: {result["cache_length"]}')
+  print(f'  time:    {result["time_s"]:.1f}s')
+  print(f'  output:  {result["output"][:120]!r}')
+  for d, p in sorted(result['peak_per_chip'].items()):
+    print(f'  chip {d} peak HBM: {_human(p)}')
+
+
+def _spawn_subprocess(script_path: str, args, mode_name: str) -> dict:
+  """Spawn a fresh Python that runs only one mode, parse its JSON line."""
+  cmd = [
+      sys.executable, script_path,
+      '--mode', mode_name,
+      '--variant', args.variant,
+      '--cache_length', str(args.cache_length),
+      '--prompt', args.prompt,
+      '--prompt_repeat', str(args.prompt_repeat),
+      '--max_new_tokens', str(args.max_new_tokens),
+      '--seed', str(args.seed),
+      '--emit_json',
+  ]
+  if args.params_fsdp:
+    cmd.append('--params_fsdp')
+  else:
+    cmd.append('--no-params_fsdp')
+
+  print(f'\n[spawning subprocess for mode={mode_name}]')
+  print(f'  cmd: {" ".join(cmd)}')
+  proc = subprocess.run(
+      cmd, capture_output=True, text=True, check=False,
+      env={**os.environ},
+  )
+  # Stream the child's stderr so the user sees compile progress / warnings.
+  if proc.stderr:
+    sys.stderr.write(proc.stderr)
+  if proc.returncode != 0:
+    print(f'  subprocess failed (returncode={proc.returncode})')
+    print(proc.stdout)
+    raise SystemExit(proc.returncode)
+  # The last non-empty line of stdout is our JSON payload (the rest is
+  # human-readable progress that we let the child print).
+  json_line = None
+  for line in proc.stdout.splitlines():
+    line = line.strip()
+    if line.startswith('{') and line.endswith('}'):
+      json_line = line
+  if json_line is None:
+    print(proc.stdout)
+    raise RuntimeError('subprocess did not emit a JSON result line')
+  return json.loads(json_line)
+
+
+def main(argv=None) -> int:
   parser = argparse.ArgumentParser(description=__doc__)
   parser.add_argument('--variant', default='e2b', choices=('e2b', 'e4b', '31b'))
   parser.add_argument('--cache_length', type=int, default=4096)
@@ -107,73 +181,67 @@ def main(argv=None) -> int:
   parser.add_argument('--params_fsdp',
                       action=argparse.BooleanOptionalAction, default=True)
   parser.add_argument('--seed', type=int, default=42)
+  parser.add_argument(
+      '--mode', choices=('legacy', 'local_window'), default=None,
+      help='If set, run only this mode in this process and emit a one-line '
+           'JSON result. Used by the driver to fork clean subprocesses; you '
+           'can also set it manually for single-mode runs.',
+  )
+  parser.add_argument(
+      '--emit_json', action='store_true',
+      help='When --mode is set, also emit a JSON line with the result on '
+           'stdout (for the driver to parse).',
+  )
   args = parser.parse_args(argv)
 
-  prompt = (args.prompt + ' ') * max(1, args.prompt_repeat)
+  if args.mode is not None:
+    # Subprocess-mode: run one cache mode, optionally emit JSON.
+    result = run_one_mode(args, args.mode)
+    _print_single_mode_report(result)
+    if args.emit_json:
+      print(json.dumps(result))
+    return 0
 
-  print(f'JAX devices: {jax.devices()}')
-  print(f'Model: {args.variant.upper()}, cache_length={args.cache_length}')
-  print(f'Prompt length (chars): {len(prompt)}')
-  print(f'max_new_tokens: {args.max_new_tokens}')
-  print('-' * 70)
+  # Driver: spawn one subprocess per mode for clean peak HBM, then compare.
+  script_path = os.path.abspath(__file__)
+  legacy = _spawn_subprocess(script_path, args, 'legacy')
+  local = _spawn_subprocess(script_path, args, 'local_window')
 
-  # ---- Run 1: LEGACY ---- (load params here, share with run 2)
-  print('\n[1/2] Running LEGACY (current behavior)...')
-  sampler_legacy, params = build_sampler(
-      args.variant, args.cache_length,
-      _cache_helper.KVCacheMode.LEGACY, args.params_fsdp,
-  )
-  t0 = time.time()
-  out_legacy = sampler_legacy.chat(
-      prompt, max_new_tokens=args.max_new_tokens, rng=args.seed,
-  )
-  legacy_time = time.time() - t0
-  legacy_peak = hbm_peak()
-  print(f'  output: {out_legacy[:120]!r}')
-  print(f'  time:   {legacy_time:.1f}s')
-  for d, p in sorted(legacy_peak.items()):
-    print(f'  chip {d} peak HBM: {_human(p)}')
-
-  del sampler_legacy
-
-  # ---- Run 2: LOCAL_WINDOW ----
-  print('\n[2/2] Running LOCAL_WINDOW...')
-  sampler_lw, _ = build_sampler(
-      args.variant, args.cache_length,
-      _cache_helper.KVCacheMode.LOCAL_WINDOW, args.params_fsdp, params=params,
-  )
-  t0 = time.time()
-  out_lw = sampler_lw.chat(
-      prompt, max_new_tokens=args.max_new_tokens, rng=args.seed,
-  )
-  lw_time = time.time() - t0
-  lw_peak = hbm_peak()
-  print(f'  output: {out_lw[:120]!r}')
-  print(f'  time:   {lw_time:.1f}s')
-  for d, p in sorted(lw_peak.items()):
-    print(f'  chip {d} peak HBM: {_human(p)}')
-
-  # ---- Compare ----
   print('\n' + '=' * 70)
   print('Equivalence check:')
-  if out_legacy == out_lw:
-    print(f'  PASS: greedy outputs match exactly.')
+  if legacy['output'] == local['output']:
+    print('  PASS: greedy outputs match exactly.')
+    print(f'    output: {legacy["output"][:120]!r}')
   else:
-    print(f'  FAIL: outputs DIFFER.')
-    print(f'    LEGACY:       {out_legacy!r}')
-    print(f'    LOCAL_WINDOW: {out_lw!r}')
+    print('  FAIL: outputs DIFFER.')
+    print(f'    LEGACY       : {legacy["output"]!r}')
+    print(f'    LOCAL_WINDOW : {local["output"]!r}')
 
-  print('\nMemory comparison (peak HBM during chat):')
+  print('\nMemory comparison (per-chip peak HBM, separate-process):')
   print(f'  {"chip":>4}  {"LEGACY":>14}  {"LOCAL_WINDOW":>14}  {"saved":>14}')
   total_saved = 0
-  for d in sorted(legacy_peak):
-    saved = legacy_peak[d] - lw_peak.get(d, 0)
+  for d in sorted(int(k) for k in legacy['peak_per_chip']):
+    leg = int(legacy['peak_per_chip'][str(d)])
+    lw = int(local['peak_per_chip'].get(str(d), 0))
+    saved = leg - lw
     total_saved += saved
-    print(f'  {d:>4}  {_human(legacy_peak[d]):>14}  '
-          f'{_human(lw_peak.get(d, 0)):>14}  {_human(saved):>14}')
-  print(f'  total peak HBM saved across slice: {_human(total_saved)}')
+    sign = '+' if saved >= 0 else ''
+    print(f'  {d:>4}  {_human(leg):>14}  {_human(lw):>14}  '
+          f'{sign}{_human(saved):>13}')
+  print(f'\n  total peak HBM saved across slice: '
+        f'{"+" if total_saved >= 0 else ""}{_human(total_saved)}')
 
-  return 0 if out_legacy == out_lw else 1
+  if total_saved <= 1024 * 1024:  # < 1 MiB
+    print('\n  Note: total saved is in the noise. Probable causes:')
+    print('    * E2B has only 1 KV head and a 512 window, so the predicted '
+          'local-cache savings at L=4096 is only ~100 MiB total - small '
+          'next to the ~5-6 GiB peak from FSDP-loaded params + activations.')
+    print('    * Try --variant e4b --cache_length 16384 (or 32768) to get a '
+          'cache big enough for the savings to be measurable.')
+
+  print(f'\n  time:    LEGACY={legacy["time_s"]:.1f}s  '
+        f'LOCAL_WINDOW={local["time_s"]:.1f}s')
+  return 0 if legacy['output'] == local['output'] else 1
 
 
 if __name__ == '__main__':

--- a/examples/cache_probe.py
+++ b/examples/cache_probe.py
@@ -1,0 +1,230 @@
+"""Runtime HBM probe for the gemma sampler.
+
+Measures per-device HBM usage before and after a real `ChatSampler.chat()`
+call, so you can see which chip(s) absorb the cache. No library edits
+needed; this is pure user-side instrumentation.
+
+What it does:
+1. Snapshots `bytes_in_use` per TPU chip via `device.memory_stats()`.
+2. Loads E2B (default) or another Gemma 4 variant + params.
+3. Builds a `gm.text.ChatSampler` exactly like a normal user would.
+4. Snapshots HBM. Runs `sampler.chat(...)`. Snapshots HBM again.
+5. Reports per-chip delta. The chip(s) that absorbed the cache will spike
+   while the others stay flat; this is the per-chip evidence for
+   Hypothesis B.
+
+Usage on TPU:
+
+    python cache_probe.py                                  # E2B, 4096 cache
+    python cache_probe.py --variant e4b --cache_length 4096
+    python cache_probe.py --variant e4b --cache_length 4096 \
+        --cache_mode local_window
+    python cache_probe.py --variant e4b --cache_length 16384
+
+Notes:
+- This loads real params, so it requires the kaggle/gcs checkpoint to be
+  accessible. If you've been running ChatSampler successfully on this
+  node, this will work the same way (same `gm.ckpts.LoadCheckpoint` /
+  `gm.ckpts.CheckpointPath` plumbing).
+- We don't pass `sharding=` to the sampler; that mirrors the documented
+  pattern from colabs/sharding.ipynb. Set `--shard params_fsdp` to apply
+  FSDP sharding to params before sampling (still no cache sharding).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import jax
+import jax.numpy as jnp
+
+
+def _human(b: float) -> str:
+  for u in ("B", "KiB", "MiB", "GiB"):
+    if abs(b) < 1024:
+      return f"{b:+.2f} {u}"
+    b /= 1024
+  return f"{b:+.2f} TiB"
+
+
+def _abs(b: float) -> str:
+  for u in ("B", "KiB", "MiB", "GiB"):
+    if b < 1024:
+      return f"{b:.2f} {u}"
+    b /= 1024
+  return f"{b:.2f} TiB"
+
+
+def hbm_snapshot() -> dict[int, dict[str, int]]:
+  """Per-device HBM stats. Returns {device_id: {bytes_in_use, peak, limit}}."""
+  out = {}
+  for d in jax.devices():
+    if not hasattr(d, "memory_stats"):
+      continue
+    try:
+      stats = d.memory_stats() or {}
+    except Exception:  # pylint: disable=broad-except
+      stats = {}
+    out[d.id] = {
+        "bytes_in_use": int(stats.get("bytes_in_use", 0)),
+        "peak_bytes_in_use": int(stats.get("peak_bytes_in_use", 0)),
+        "bytes_limit": int(stats.get("bytes_limit", 0)),
+    }
+  return out
+
+
+def print_snapshot(title: str, snap: dict[int, dict[str, int]]) -> None:
+  print(f"\n--- {title} ---")
+  print(f"  {'chip':>4}  {'in_use':>14}  {'peak':>14}  {'limit':>14}")
+  for d_id in sorted(snap):
+    s = snap[d_id]
+    print(f"  {d_id:>4}  {_abs(s['bytes_in_use']):>14}  "
+          f"{_abs(s['peak_bytes_in_use']):>14}  "
+          f"{_abs(s['bytes_limit']):>14}")
+
+
+def print_delta(pre, post, title="Per-chip delta from chat()") -> None:
+  print(f"\n--- {title} ---")
+  print(f"  {'chip':>4}  {'pre':>14}  {'post':>14}  {'delta':>14}")
+  total = 0
+  for d_id in sorted(pre):
+    pre_b = pre[d_id]["bytes_in_use"]
+    post_b = post[d_id]["bytes_in_use"]
+    delta = post_b - pre_b
+    total += delta
+    print(f"  {d_id:>4}  {_abs(pre_b):>14}  {_abs(post_b):>14}  "
+          f"{_human(delta):>14}")
+  print(f"  total delta across all chips: {_human(total)}")
+
+
+def build_sampler(
+    variant: str, *, cache_length: int, cache_mode, params_fsdp: bool
+):
+  from gemma import gm  # pylint: disable=g-import-not-at-top
+
+  variants = {
+      "e2b": (gm.nn.Gemma4_E2B, "GEMMA4_E2B_IT"),
+      "e4b": (gm.nn.Gemma4_E4B, "GEMMA4_E4B_IT"),
+      "31b": (gm.nn.Gemma4_31B, "GEMMA4_31B_IT"),
+  }
+  cls, ckpt_name = variants[variant.lower()]
+  print(f"Building model {cls.__name__}...")
+  model = cls()
+
+  print(f"Loading checkpoint {ckpt_name} "
+        f"(params_fsdp={params_fsdp})...")
+  ckpt_path = getattr(gm.ckpts.CheckpointPath, ckpt_name)
+  if params_fsdp:
+    # Without FSDP, large checkpoints (E4B / 31B) try to land on a single
+    # chip and OOM during deserialization, even before any sampler call.
+    # FSDP-shards the params across the slice during load_params.
+    from kauldron import kd  # pylint: disable=g-import-not-at-top
+    sharding = kd.sharding.FSDPSharding()
+    params = gm.ckpts.load_params(ckpt_path, sharding=sharding)
+  else:
+    params = gm.ckpts.load_params(ckpt_path)
+
+  print(f"Constructing ChatSampler(cache_length={cache_length}, "
+        f"cache_mode={cache_mode.value})...")
+  sampler = gm.text.ChatSampler(
+      model=model,
+      params=params,
+      cache_length=cache_length,
+      kv_cache_mode=cache_mode,
+  )
+  return sampler
+
+
+def main(argv=None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--variant", default="e2b",
+                      choices=("e2b", "e4b", "31b"))
+  parser.add_argument("--cache_length", type=int, default=4096)
+  parser.add_argument("--cache_mode", default="legacy",
+                      choices=("legacy", "local_window"),
+                      help="KV cache allocation mode to probe.")
+  parser.add_argument("--prompt", default="Tell me a short fun fact.")
+  parser.add_argument("--max_new_tokens", type=int, default=64,
+                      help="Cap output length so probe is fast.")
+  parser.add_argument("--params_fsdp", action=argparse.BooleanOptionalAction,
+                      default=True,
+                      help="Apply FSDP sharding to params during load. "
+                           "ON by default (mirrors production deployment "
+                           "and prevents single-chip OOM during checkpoint "
+                           "load on E4B+). Use --no-params_fsdp to disable.")
+  args = parser.parse_args(argv)
+
+  print(f"JAX version: {jax.__version__}")
+  print(f"JAX devices: {jax.devices()}")
+  from gemma.gm.utils import (  # pylint: disable=g-import-not-at-top
+      _cache_helper,
+  )
+  cache_mode = _cache_helper.KVCacheMode(args.cache_mode)
+
+  print_snapshot("HBM at startup (no params loaded yet)", hbm_snapshot())
+
+  sampler = build_sampler(
+      args.variant,
+      cache_length=args.cache_length,
+      cache_mode=cache_mode,
+      params_fsdp=args.params_fsdp,
+  )
+
+  pre = hbm_snapshot()
+  print_snapshot("HBM after sampler construction (params loaded)", pre)
+
+  print(f"\nRunning chat() - first-call compile + actual sampling...")
+  t0 = time.time()
+  out = sampler.chat(args.prompt, max_new_tokens=args.max_new_tokens,
+                     multi_turn=False)
+  print(f"  done in {time.time() - t0:.1f}s")
+  print(f"  output (first 80 chars): {out[:80]!r}")
+
+  post = hbm_snapshot()
+  print_snapshot("HBM after chat() (in_use is post-call; peak is the spike)",
+                 post)
+  print_delta(pre, post)
+  # The cache is allocated DURING chat() and may be released by the time
+  # we snapshot post-call. The peak_bytes_in_use field captures the spike.
+  print("\n--- Peak HBM during chat() (relative to pre) ---")
+  print(f"  {'chip':>4}  {'pre_peak':>14}  {'post_peak':>14}  "
+        f"{'peak_delta':>14}")
+  for d_id in sorted(pre):
+    pre_p = pre[d_id]["peak_bytes_in_use"]
+    post_p = post[d_id]["peak_bytes_in_use"]
+    print(f"  {d_id:>4}  {_abs(pre_p):>14}  {_abs(post_p):>14}  "
+          f"{_human(post_p - pre_p):>14}")
+
+  # Summary: how lopsided is the per-chip PEAK distribution?
+  peak_deltas = sorted(
+      (post[d]["peak_bytes_in_use"] - pre[d]["peak_bytes_in_use"]
+       for d in pre),
+      reverse=True,
+  )
+  if len(peak_deltas) >= 2:
+    biggest = peak_deltas[0]
+    rest_avg = sum(peak_deltas[1:]) / max(1, len(peak_deltas) - 1)
+    print("\nVerdict (based on peak HBM spike during chat):")
+    if biggest > 4 * max(1, abs(rest_avg)):
+      print("  Cache is concentrated on one chip "
+            f"(biggest peak delta = {_human(biggest)}, others avg = "
+            f"{_human(rest_avg)}). Confirms Hypothesis B: cache is NOT "
+            "sharded across the slice.")
+    elif biggest <= 1024 * 1024:
+      print("  No measurable peak delta (<1 MiB). The probe may not have "
+            "captured the spike; try a larger cache_length.")
+    elif all(d > 0.5 * biggest for d in peak_deltas):
+      print("  Cache spike is roughly even across chips; sharding is "
+            "happening somewhere (or the cache is replicated, which uses "
+            "the same memory on every chip).")
+    else:
+      print("  Cache spike is uneven across chips. Inspect the per-chip "
+            "table above to see which chip(s) absorbed it.")
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/gemma/gm/nn/gemma4/_config.py
+++ b/gemma/gm/nn/gemma4/_config.py
@@ -22,6 +22,7 @@ from gemma.gm.nn.gemma4 import _modules
 from gemma.gm.nn.gemma4.audio import _modules as gemma4_audio
 from gemma.gm.nn.gemma4.vision import _encoder as gemma4_vision
 from gemma.gm.text import _tokenizer
+from gemma.gm.utils import _cache_helper
 from gemma.gm.utils import _types
 import jax.numpy as jnp
 
@@ -160,13 +161,44 @@ class TransformerConfig:
       dtype: jnp.dtype = jnp.bfloat16,
       *,
       cache_length: int,
+      kv_cache_mode: _cache_helper.KVCacheMode = (
+          _cache_helper.KVCacheMode.LEGACY
+      ),
   ) -> Cache:
-    """Initializes a new Transformer cache."""
+    """Initializes a new Transformer cache.
+
+    Args:
+      batch_size: cache batch size.
+      dtype: dtype for K/V buffers.
+      cache_length: full logical cache length (used for global layers; also
+        the upper bound for local-window layers).
+      kv_cache_mode: KV cache allocation policy.
+        - LEGACY: every layer gets `[B, cache_length, ...]` (default).
+        - LOCAL_WINDOW: LOCAL_SLIDING layers are sized to
+          `min(cache_length, sliding_window_size)` slots and carry ring-buffer
+          metadata (`logical_index`, `valid`); GLOBAL layers stay at
+          `cache_length`. Saves a large fraction of HBM at long context.
+    """
     if cache_length is None:
       raise ValueError(
           'Missing `cache_length=` kwarg when calling `init_cache()`.'
       )
     cache: Cache = {}
+
+    use_local_window = (
+        kv_cache_mode == _cache_helper.KVCacheMode.LOCAL_WINDOW
+        and self.sliding_window_size is not None
+    )
+    # Per the design review: persistent local cache is exactly the sliding
+    # window size, NOT window+1. The sliding mask is strict-bounded
+    # (cache_position > pos - W and cache_position < pos + W), so for causal
+    # decode the cache must hold the current token plus the previous W-1, i.e.
+    # W slots total.
+    local_window_size = (
+        min(cache_length, self.sliding_window_size)
+        if use_local_window
+        else cache_length
+    )
 
     for i, attn_type in enumerate(self.attention_types):
       if (
@@ -182,6 +214,23 @@ class TransformerConfig:
             batch_size,
             dtype,
         )
+      elif attn_type == _modules.AttentionType.LOCAL_SLIDING:
+        if use_local_window:
+          cache[f'layer_{i}'] = _modules.Attention.init_local_window_cache(
+              local_window_size,
+              self.num_kv_heads,
+              self.head_dim,
+              batch_size,
+              dtype,
+          )
+        else:
+          cache[f'layer_{i}'] = _modules.Attention.init_cache(
+              cache_length,
+              self.num_kv_heads,
+              self.head_dim,
+              batch_size,
+              dtype,
+          )
       else:
         cache[f'layer_{i}'] = _modules.Attention.init_cache(
             cache_length,

--- a/gemma/gm/nn/gemma4/_modules.py
+++ b/gemma/gm/nn/gemma4/_modules.py
@@ -292,16 +292,39 @@ class Attention(nn.Module):
           rope_proportion=self.rope_proportion,
       )
 
-    # Cache is left aligned.
+    # Cache is left aligned (legacy) or ring-buffered (LOCAL_WINDOW).
     # Save the KV values to the cache.
+    cache_logical_index = None
+    cache_valid = None
     if kv_shared_cache is not None:
       cache_positions = kv_shared_cache.get('positions')
+      # If the donor layer is a LOCAL_WINDOW cache, borrow its ring-buffer
+      # metadata so this receiver's attention call applies the same mask
+      # gather (otherwise key_proj would be [B, W, ...] while attn_mask is
+      # [B, T, cache_length_logical], causing a shape mismatch).
+      if 'logical_index' in kv_shared_cache:
+        cache_logical_index = kv_shared_cache['logical_index']
+      if 'valid' in kv_shared_cache:
+        cache_valid = kv_shared_cache['valid']
     elif cache is not None:
       end_index = cache['end_index']
       cache_size = cache['v'].shape[1]
       seq_len = x.shape[1]
-      # [batch_size, seq_len]
-      indices = (end_index[:, None] + jnp.arange(seq_len)[None, :]) % cache_size
+      is_local_window_cache = 'logical_index' in cache and 'valid' in cache
+      # [batch_size, seq_len] - logical cache indices used by the sampler's
+      # full attention mask.
+      logical_indices = (
+          end_index[:, None] + jnp.arange(seq_len)[None, :]
+      ).astype(jnp.int32)
+      if is_local_window_cache:
+        # LOCAL_WINDOW eviction follows RoPE/sliding positions, not the padded
+        # logical cache timeline. This matters for batches where one example is
+        # short and another example forces a much larger padded prefill length:
+        # the short example's local context should not be evicted by padding.
+        indices = segment_pos.astype(jnp.int32) % cache_size
+      else:
+        # Legacy/full caches are addressed by logical cache index.
+        indices = logical_indices % cache_size
       batch_indices = jnp.arange(x.shape[0])[:, None]
 
       # [batch_size, cache_size, num_heads, key_size]
@@ -314,6 +337,33 @@ class Attention(nn.Module):
       cache_positions = (
           cache['positions'].at[batch_indices, indices].set(segment_pos)
       )
+
+      # LOCAL_WINDOW ring-buffer metadata maintenance. The logical index is
+      # only used to map the sampler's full logical mask onto physical local
+      # slots. If the current logical write is masked out (the first decode
+      # step for a padded row recomputes the last real prompt token at a
+      # padded logical slot), keep the previous metadata while still allowing
+      # the equivalent K/V value to refresh the slot.
+      if is_local_window_cache:
+        logical_len = attn_mask.shape[-1]
+        safe_logical_indices = jnp.clip(logical_indices, 0, logical_len - 1)
+        logical_write_valid = jnp.take_along_axis(
+            attn_mask, safe_logical_indices[..., None], axis=-1
+        )[..., 0]
+        old_logical_index = cache['logical_index'][batch_indices, indices]
+        old_valid = cache['valid'][batch_indices, indices]
+        cache_logical_index = (
+            cache['logical_index']
+            .at[batch_indices, indices]
+            .set(jnp.where(
+                logical_write_valid, logical_indices, old_logical_index
+            ))
+        )
+        cache_valid = (
+            cache['valid']
+            .at[batch_indices, indices]
+            .set(jnp.where(logical_write_valid, True, old_valid))
+        )
     else:
       cache_positions = None
 
@@ -345,6 +395,24 @@ class Attention(nn.Module):
           cache_positions=cache_positions,
           sliding_window_size=self.sliding_window_size,
       )
+      # LOCAL_WINDOW: the logical attn_mask is keyed by logical position
+      # (slot s <-> token s). Once the local cache is a ring buffer of size W,
+      # physical slot s no longer maps to logical token s. We gather the
+      # logical mask onto the physical slot layout via `logical_index`, and
+      # AND with `valid` to drop unwritten slots. This is a no-op for LEGACY
+      # caches because their `cache_size == attn_mask.shape[-1]`.
+      if cache_logical_index is not None and cache_valid is not None:
+        logical_len = attn_mask.shape[-1]
+        # Clip to keep gather indices in-bounds (slots whose logical_index
+        # is -1 are the unwritten ones; the `valid` mask zeroes them out
+        # below). We use a take_along_axis because the logical-index pattern
+        # is per-batch.
+        safe_index = jnp.clip(cache_logical_index, 0, logical_len - 1)
+        # [B, 1, cache_size] broadcasts against [B, seq_len, logical_len].
+        attn_mask = jnp.take_along_axis(
+            attn_mask, safe_index[:, None, :], axis=-1,
+        )
+        attn_mask = attn_mask & cache_valid[:, None, :]
       # [batch_size, seq_len, cache_size]
       attn_mask *= sliding_mask
 
@@ -391,6 +459,13 @@ class Attention(nn.Module):
       ), 'cache_positions should not be None when cache is not None'
       # [batch_size, cache_size]
       new_cache['positions'] = cache_positions
+      # LOCAL_WINDOW ring-buffer metadata (only present for local layers in
+      # local_window mode). Forwarded so the next step's attention call sees
+      # the up-to-date logical-index / valid maps.
+      if cache_logical_index is not None:
+        new_cache['logical_index'] = cache_logical_index
+      if cache_valid is not None:
+        new_cache['valid'] = cache_valid
 
     return new_cache, attn_output
 
@@ -414,6 +489,50 @@ class Attention(nn.Module):
         'end_index': jnp.zeros((batch_size,), dtype=jnp.int32),
         # Save the positions for the sliding window attention.
         'positions': jnp.zeros((batch_size, cache_size), dtype=jnp.int32),
+    }
+
+  @classmethod
+  def init_local_window_cache(
+      cls,
+      window_size: int,
+      num_heads: int,
+      head_dim: int,
+      batch_size: int,
+      dtype: jnp.dtype = jnp.bfloat16,
+  ) -> LayerCache:
+    """Initialize a ring-buffer cache for a LOCAL_SLIDING attention layer.
+
+    Differs from `init_cache` in two ways:
+    1. Seq dim is `window_size` (e.g. 512 or 1024), not the global
+       `cache_length`. This is the dominant memory win.
+    2. Carries two extra metadata fields, `logical_index` and `valid`, that
+       let `Attention.__call__` map the logical full attention mask onto the
+       physical ring-buffer slot layout. Without these, after the ring wraps,
+       there is no way to know whether physical slot s holds a non-padding
+       token, because the slot index no longer matches the logical position.
+    """
+    del cls  # not used
+    return {
+        'v': jnp.zeros(
+            (batch_size, window_size, num_heads, head_dim), dtype=dtype
+        ),
+        'k': jnp.zeros(
+            (batch_size, window_size, num_heads, head_dim), dtype=dtype
+        ),
+        'end_index': jnp.zeros((batch_size,), dtype=jnp.int32),
+        # RoPE / sliding-mask positions; large negative sentinel so any
+        # unwritten slot is always outside the sliding window.
+        'positions': jnp.full(
+            (batch_size, window_size), -(10**9), dtype=jnp.int32
+        ),
+        # The logical (pre-modulo) token index stored at this physical slot.
+        # Used at attention time to gather the logical attn_mask onto the
+        # physical slot layout. -1 = uninitialized.
+        'logical_index': jnp.full(
+            (batch_size, window_size), -1, dtype=jnp.int32
+        ),
+        # Whether this physical slot has been written with real KV.
+        'valid': jnp.zeros((batch_size, window_size), dtype=jnp.bool_),
     }
 
 

--- a/gemma/gm/nn/gemma4/_transformer.py
+++ b/gemma/gm/nn/gemma4/_transformer.py
@@ -30,6 +30,7 @@ from gemma.gm.nn.gemma4 import _modules
 from gemma.gm.nn.gemma4.audio import _model as gemma4_audio_model
 from gemma.gm.nn.gemma4.vision import _encoder as gemma4_vision
 from gemma.gm.utils import _attention_mask
+from gemma.gm.utils import _cache_helper
 from gemma.gm.utils import _dtype_params
 from gemma.gm.utils import _jax_utils
 from gemma.gm.utils import _types
@@ -394,6 +395,7 @@ class Transformer(nn.Module):
           'dtype',
           'cache_length',
           'sharding',
+          'kv_cache_mode',
       ),
   )
   def init_cache(
@@ -403,11 +405,15 @@ class Transformer(nn.Module):
       dtype: jnp.dtype[Any],
       cache_length: int,
       sharding: kd.sharding.ShardingTree | None = None,
+      kv_cache_mode: _cache_helper.KVCacheMode = (
+          _cache_helper.KVCacheMode.LEGACY
+      ),
   ) -> _config.Cache:
     cache = self.config.init_cache(
         batch_size=batch_size,
         dtype=dtype,
         cache_length=cache_length,
+        kv_cache_mode=kv_cache_mode,
     )
     return kd.sharding.with_sharding_constraint(cache, sharding)
 

--- a/gemma/gm/nn/gemma4/_transformer_test.py
+++ b/gemma/gm/nn/gemma4/_transformer_test.py
@@ -14,10 +14,14 @@
 
 from typing import Any
 
+from gemma.gm.nn.gemma4 import _config
 from gemma.gm.nn.gemma4 import _gemma4 as gemma4_models
+from gemma.gm.nn.gemma4 import _modules
 from gemma.gm.nn.gemma4 import _transformer as gt
+from gemma.gm.utils import _cache_helper
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 
@@ -57,3 +61,94 @@ def test_text_only():
   out, params = _get_output(model, tokens=tokens)
   assert 'vision_encoder' not in params
   assert out.logits.shape == (BATCH_SIZE, SEQ_LEN, model.config.num_embed)
+
+
+def test_init_cache_local_window_shapes():
+  config = _config.TransformerConfig(
+      num_embed=32,
+      embed_dim=8,
+      hidden_dim=16,
+      num_heads=2,
+      head_dim=4,
+      num_kv_heads=1,
+      final_logit_softcap=None,
+      use_post_attn_norm=False,
+      use_post_ffw_norm=False,
+      attention_types=(
+          _modules.AttentionType.LOCAL_SLIDING,
+          _modules.AttentionType.GLOBAL,
+      ),
+      sliding_window_size=4,
+      global_key_size=6,
+      num_global_kv_heads=1,
+  )
+
+  cache = config.init_cache(
+      batch_size=2,
+      dtype=jnp.float32,
+      cache_length=10,
+      kv_cache_mode=_cache_helper.KVCacheMode.LOCAL_WINDOW,
+  )
+
+  assert cache['layer_0']['k'].shape == (2, 4, 1, 4)
+  assert cache['layer_0']['v'].shape == (2, 4, 1, 4)
+  assert cache['layer_0']['positions'].shape == (2, 4)
+  assert cache['layer_0']['logical_index'].shape == (2, 4)
+  assert cache['layer_0']['valid'].shape == (2, 4)
+  np.testing.assert_array_equal(cache['layer_0']['logical_index'], -1)
+  np.testing.assert_array_equal(cache['layer_0']['valid'], False)
+  np.testing.assert_array_equal(cache['layer_0']['positions'], -(10**9))
+
+  assert cache['layer_1']['k'].shape == (2, 10, 1, 6)
+  assert 'logical_index' not in cache['layer_1']
+
+
+def test_init_cache_local_window_uses_window_not_window_plus_one():
+  config = _config.TransformerConfig(
+      num_embed=32,
+      embed_dim=8,
+      hidden_dim=16,
+      num_heads=2,
+      head_dim=4,
+      num_kv_heads=1,
+      final_logit_softcap=None,
+      use_post_attn_norm=False,
+      use_post_ffw_norm=False,
+      attention_types=(_modules.AttentionType.LOCAL_SLIDING,),
+      sliding_window_size=4,
+  )
+
+  cache = config.init_cache(
+      batch_size=1,
+      dtype=jnp.float32,
+      cache_length=10,
+      kv_cache_mode=_cache_helper.KVCacheMode.LOCAL_WINDOW,
+  )
+
+  assert cache['layer_0']['k'].shape[1] == 4
+
+
+def test_init_cache_local_window_does_not_shrink_global_without_global_key():
+  config = _config.TransformerConfig(
+      num_embed=32,
+      embed_dim=8,
+      hidden_dim=16,
+      num_heads=2,
+      head_dim=4,
+      num_kv_heads=1,
+      final_logit_softcap=None,
+      use_post_attn_norm=False,
+      use_post_ffw_norm=False,
+      attention_types=(_modules.AttentionType.GLOBAL,),
+      sliding_window_size=4,
+  )
+
+  cache = config.init_cache(
+      batch_size=1,
+      dtype=jnp.float32,
+      cache_length=10,
+      kv_cache_mode=_cache_helper.KVCacheMode.LOCAL_WINDOW,
+  )
+
+  assert cache['layer_0']['k'].shape == (1, 10, 1, 4)
+  assert 'logical_index' not in cache['layer_0']

--- a/gemma/gm/text/_chat_sampler.py
+++ b/gemma/gm/text/_chat_sampler.py
@@ -30,6 +30,7 @@ from gemma.gm.text import _sampling
 from gemma.gm.text import _template
 from gemma.gm.text import _tokenizer
 from gemma.gm.typing import _common
+from gemma.gm.utils import _cache_helper
 # from gemma.gm.vision import _token_utils
 from kauldron import kd
 from kauldron.ktyping import UInt8  # pylint: disable=g-multiple-import,g-importing-member
@@ -134,6 +135,18 @@ class ChatSampler:
   pooling_kernel_size: int = 3
   audio_sample_rate: int = 16000
   audio_seq_length: int = 750
+  # KV cache allocation policy. Forwarded to Gemma4Sampler. See
+  # _cache_helper.KVCacheMode for the modes; LEGACY is the default and
+  # backwards-compatible. Override per session via the env var
+  # GEMMA_KV_CACHE_MODE=local_window.
+  kv_cache_mode: _cache_helper.KVCacheMode = dataclasses.field(
+      default_factory=lambda: _cache_helper.KVCacheMode.from_env()
+  )
+  # Forwarded to Gemma4Sampler. Override per session via
+  # GEMMA_KV_PREFILL_MODE=legacy_scratch.
+  kv_prefill_mode: _cache_helper.KVPrefillMode = dataclasses.field(
+      default_factory=lambda: _cache_helper.KVPrefillMode.from_env()
+  )
 
   # Internal variables, but exposed for power users.
 
@@ -182,6 +195,8 @@ class ChatSampler:
           pooling_kernel_size=self.pooling_kernel_size,
           audio_sample_rate=self.audio_sample_rate,
           audio_seq_length=self.audio_seq_length,
+          kv_cache_mode=self.kv_cache_mode,
+          kv_prefill_mode=self.kv_prefill_mode,
       )
     else:
       return _sampler.Sampler(

--- a/gemma/gm/text/_gemma4_sampler.py
+++ b/gemma/gm/text/_gemma4_sampler.py
@@ -30,6 +30,7 @@ from gemma.gm.text import _sampler_loop
 from gemma.gm.text import _sampling
 from gemma.gm.text import _tokenizer
 from gemma.gm.typing import _common
+from gemma.gm.utils import _cache_helper
 from gemma.gm.utils import _types
 from gemma.gm.vision import _token_utils
 import jax
@@ -81,6 +82,18 @@ class Gemma4Sampler:
   pooling_kernel_size: int = 3
   audio_sample_rate: int = 16000
   audio_seq_length: int = 750
+  # KV cache allocation policy. LEGACY = full cache_length on every layer
+  # (default, backwards-compatible). LOCAL_WINDOW = ring-buffered local
+  # layers, full global, with mask gather via logical_index. The env var
+  # `GEMMA_KV_CACHE_MODE=local_window` overrides per call site at __post_init__.
+  kv_cache_mode: _cache_helper.KVCacheMode = dataclasses.field(
+      default_factory=lambda: _cache_helper.KVCacheMode.from_env()
+  )
+  # Prefill strategy. LEGACY_SCRATCH is correctness-first and currently the
+  # only implemented mode. Override with GEMMA_KV_PREFILL_MODE.
+  kv_prefill_mode: _cache_helper.KVPrefillMode = dataclasses.field(
+      default_factory=lambda: _cache_helper.KVPrefillMode.from_env()
+  )
 
   def __post_init__(self):
     if self.tokenizer is None:
@@ -217,6 +230,8 @@ class Gemma4Sampler:
         audio=audio,
         audio_lengths=audio_lengths,
         audio_soft_token_counts=tuple(audio_soft_token_counts),
+        kv_cache_mode=self.kv_cache_mode,
+        kv_prefill_mode=self.kv_prefill_mode,
     )
 
     if max_new_tokens and max_new_tokens > self.max_out_length:

--- a/gemma/gm/text/_prefill.py
+++ b/gemma/gm/text/_prefill.py
@@ -63,6 +63,12 @@ def prefill(
     audio=None,
     audio_lengths=None,
     audio_soft_token_counts=None,
+    kv_cache_mode: _cache_helper.KVCacheMode = (
+        _cache_helper.KVCacheMode.LEGACY
+    ),
+    kv_prefill_mode: _cache_helper.KVPrefillMode = (
+        _cache_helper.KVPrefillMode.LEGACY_SCRATCH
+    ),
 ) -> _sampler_loop.SamplingState:
   """Pre-fill the KV cache and initial model input.
 
@@ -83,6 +89,8 @@ def prefill(
     audio: Audio input data or None.
     audio_lengths: Lengths of audio inputs or None.
     audio_soft_token_counts: Soft token counts for audio or None.
+    kv_cache_mode: KV cache allocation/storage policy.
+    kv_prefill_mode: KV cache prefill strategy.
 
   Returns:
     The initial state for the sampling loop.
@@ -90,6 +98,12 @@ def prefill(
 
   if isinstance(pad_length, int):
     pad_length = (pad_length,)
+
+  if kv_prefill_mode != _cache_helper.KVPrefillMode.LEGACY_SCRATCH:
+    raise NotImplementedError(
+        f'Unsupported kv_prefill_mode={kv_prefill_mode!r}. Only '
+        'LEGACY_SCRATCH is implemented.'
+    )
 
   # Wrap the last state to simplify the logic of adding the previous turns to
   # the prefill.
@@ -105,15 +119,40 @@ def prefill(
       params=params,
       cache_length=cache_length,
       sharding=sharding,
+      kv_cache_mode=kv_cache_mode,
   )
 
-  prefill_input = _make_prefill_input(
-      input=input,
-      cache=full_cache,
-      prev_turns=prev_turns,
-      pad_lengths=pad_length,
-      vision_input=vision_input,
+  # LOCAL_WINDOW correctness: the persistent local cache is a ring buffer of
+  # `sliding_window_size` slots, but prefill must compute attention over the
+  # full prompt without mod-wrap (otherwise an early prompt token's KV gets
+  # overwritten before later tokens attend to it). We therefore allocate a
+  # full-size SCRATCH cache for local layers during prefill, run prefill
+  # normally (legacy semantics inside Attention.__call__ because the scratch
+  # carries no `logical_index` metadata), then compact each row's last valid
+  # local-window tokens back into the persistent ring buffer.
+  using_local_window = (
+      kv_cache_mode == _cache_helper.KVCacheMode.LOCAL_WINDOW
+      and any(_cache_helper.is_local_window_layer(d)
+              for d in full_cache.cache.values())
   )
+
+  if using_local_window:
+    prefill_input = _make_prefill_input_local_window(
+        input=input,
+        cache=full_cache,
+        prev_turns=prev_turns,
+        pad_lengths=pad_length,
+        model=model,
+        vision_input=vision_input,
+    )
+  else:
+    prefill_input = _make_prefill_input(
+        input=input,
+        cache=full_cache,
+        prev_turns=prev_turns,
+        pad_lengths=pad_length,
+        vision_input=vision_input,
+    )
 
   images_for_model = (
       vision_input if vision_input is not None else prefill_input.images
@@ -148,10 +187,18 @@ def prefill(
   # TODO(epot): Could check whether the cache is full.
 
   # Write the new cache back to the full cache.
-  cache = _merge_cache(
-      full_cache=full_cache,
-      prefill_cache=out.cache,
-  )
+  if using_local_window:
+    cache = _merge_cache_local_window(
+        full_cache=full_cache,
+        prefill_cache=out.cache,
+        logical_valid_mask=prefill_input.attention_mask[:, -1, :],
+        model=model,
+    )
+  else:
+    cache = _merge_cache(
+        full_cache=full_cache,
+        prefill_cache=out.cache,
+    )
   del out
 
   # Set the end index (which indicates the last kv cache index used).
@@ -232,6 +279,7 @@ def prefill(
       new_used_cache_length=new_used_cache_length,
       prev_turns=prev_turns,
       cache=cache,
+      cache_length=cache_length,
       rng=rng,
   )
 
@@ -243,6 +291,7 @@ def _make_init_state(
     new_used_cache_length: int,
     prev_turns: _turn_utils.PrevTurns,
     cache: _cache_helper.Cache,
+    cache_length: int,
     rng: PRNGKey,
 ) -> _sampler_loop.SamplingState:
   """Initial state for the sampling loop."""
@@ -254,7 +303,7 @@ def _make_init_state(
   full_attention_mask = _make_full_attention_mask(
       input=input,
       prev_turns=prev_turns,
-      cache_length=cache.total_cache_length,
+      cache_length=cache_length,
   )
 
   return _sampler_loop.SamplingState(
@@ -288,16 +337,24 @@ def _get_or_init_cache(
     params: _common.Params,
     cache_length: int,
     sharding: kd.sharding.ShardingTree | None,
+    kv_cache_mode: _cache_helper.KVCacheMode = (
+        _cache_helper.KVCacheMode.LEGACY
+    ),
 ) -> _cache_helper.Cache:
   """Initialize or reuse the cache."""
 
   if not prev_turns:
-    cache = model.init_cache(
-        batch_size=inputs.batch_size,
-        dtype=_dtype(params),
-        cache_length=cache_length,
-        sharding=sharding,
-    )
+    init_kwargs = {
+        'batch_size': inputs.batch_size,
+        'dtype': _dtype(params),
+        'cache_length': cache_length,
+        'sharding': sharding,
+    }
+    # Only forward kv_cache_mode if the model accepts it (Gemma 4 path).
+    # Older transformer .init_cache signatures will reject the kwarg.
+    if kv_cache_mode != _cache_helper.KVCacheMode.LEGACY:
+      init_kwargs['kv_cache_mode'] = kv_cache_mode
+    cache = model.init_cache(**init_kwargs)
   else:
     # TODO(epot): Should check shape is compatible with `cache_length`.
     cache = prev_turns.cache
@@ -364,6 +421,234 @@ def _merge_cache(
   return full_cache.at[:, : prefill_cache.total_cache_length].set_kv(
       prefill_cache
   )
+
+
+def _make_prefill_input_local_window(
+    input: _types.Input,  # pylint: disable=redefined-builtin
+    cache: _cache_helper.Cache,
+    prev_turns: _turn_utils.PrevTurns,
+    pad_lengths: tuple[int, ...],
+    model: _transformer_like.TransformerLike,
+    vision_input=None,  # pylint: disable=unused-argument
+) -> PrefillInput:
+  """Make the transformer inputs for the prefill stage in LOCAL_WINDOW mode.
+
+  Local-sliding layers in the persistent cache are window-sized ring buffers,
+  but prefill needs a contiguous, non-wrapping cache so that the prompt's
+  attention math is correct when prompt_length > sliding_window_size. We
+  allocate fresh full-size scratch K/V for local layers; global layers are
+  sliced from the persistent cache as in the LEGACY path. Metadata fields
+  (`logical_index`, `valid`) are NOT included in the scratch. That is
+  deliberate, so `Attention.__call__` takes the legacy code path during
+  prefill.
+  """
+  token_length_padded = _pad_to_bucket(input.length_with_mm, pad_lengths)
+  input = input.pad(length_with_mm=token_length_padded)
+
+  prefill_cache_length = prev_turns.used_cache_length + token_length_padded
+  prefill_cache_length = _pad_to_bucket(prefill_cache_length, pad_lengths)
+
+  scratch: _config.Cache = {}
+  config = model.config
+  for i, _ in enumerate(config.attention_types):
+    layer_name = f'layer_{i}'
+    persistent_layer = cache.cache[layer_name]
+    if _cache_helper.is_local_window_layer(persistent_layer):
+      # Fresh full-size scratch for this local layer (legacy shape, no
+      # metadata, so Attention.__call__ takes the legacy code path). Previous
+      # local-window turns are re-expanded into their logical scratch slots
+      # before the new prompt is appended.
+      scratch[layer_name] = _make_local_window_prefill_scratch_layer(
+          persistent_layer=persistent_layer,
+          prefill_cache_length=prefill_cache_length,
+      )
+    else:
+      # Global / legacy: slice the persistent cache prefix as in the
+      # LEGACY path. Slicing returns views; downstream merge writes back.
+      scratch[layer_name] = {
+          'k': persistent_layer['k'][:, :prefill_cache_length],
+          'v': persistent_layer['v'][:, :prefill_cache_length],
+          'positions': persistent_layer['positions'][:, :prefill_cache_length],
+          'end_index': persistent_layer['end_index'],
+      }
+
+  return PrefillInput(
+      tokens=input.text,
+      images=input.images,
+      positions=input.positions + prev_turns.last_token_pos[..., None],
+      attention_mask=prev_turns.make_prefill_attention_mask(
+          next_turn_attention_mask=input.attention_mask,
+          prefill_cache_length=prefill_cache_length,
+      ),
+      cache=_cache_helper.Cache(scratch),
+  )
+
+
+def _make_local_window_prefill_scratch_layer(
+    *,
+    persistent_layer: dict,
+    prefill_cache_length: int,
+) -> dict:
+  """Re-expand a local-window layer into a full logical prefill scratch."""
+  b, _, num_kv_heads, head_dim = persistent_layer['k'].shape
+  scratch = {
+      'k': jnp.zeros(
+          (b, prefill_cache_length, num_kv_heads, head_dim),
+          dtype=persistent_layer['k'].dtype,
+      ),
+      'v': jnp.zeros(
+          (b, prefill_cache_length, num_kv_heads, head_dim),
+          dtype=persistent_layer['v'].dtype,
+      ),
+      'positions': jnp.full(
+          (b, prefill_cache_length), -(10**9), dtype=jnp.int32
+      ),
+      'end_index': persistent_layer['end_index'],
+  }
+
+  logical_index = persistent_layer['logical_index']
+  valid = persistent_layer['valid'] & (logical_index >= 0)
+  valid = valid & (logical_index < prefill_cache_length)
+  scatter_index = jnp.where(valid, logical_index, prefill_cache_length)
+  batch_indices = jnp.arange(b)[:, None]
+
+  scratch['k'] = scratch['k'].at[batch_indices, scatter_index].set(
+      persistent_layer['k'], mode='drop'
+  )
+  scratch['v'] = scratch['v'].at[batch_indices, scatter_index].set(
+      persistent_layer['v'], mode='drop'
+  )
+  scratch['positions'] = scratch['positions'].at[
+      batch_indices, scatter_index
+  ].set(persistent_layer['positions'], mode='drop')
+  return scratch
+
+
+def _merge_cache_local_window(
+    *,
+    full_cache: _cache_helper.Cache,
+    prefill_cache: _config.Cache,
+    logical_valid_mask: jax.Array,
+    model: _transformer_like.TransformerLike,
+) -> _cache_helper.Cache:
+  """Merge a LOCAL_WINDOW prefill back into the persistent cache.
+
+  - Global layers: copy the prefill prefix into the persistent prefix (the
+    LEGACY merge path).
+  - Local layers: compact the last W valid logical slots for each batch row
+    into the persistent W-slot ring buffer, placing each token at
+    `absolute_position % W`. Also writes the new `logical_index` and `valid`
+    metadata.
+  """
+  config = model.config
+  full_dict = full_cache.cache
+  new_dict: _config.Cache = {}
+
+  for i, _ in enumerate(config.attention_types):
+    layer_name = f'layer_{i}'
+    persistent_layer = full_dict[layer_name]
+    prefill_layer = prefill_cache[layer_name]
+
+    if _cache_helper.is_local_window_layer(persistent_layer):
+      new_dict[layer_name] = _compact_local_window_layer(
+          persistent_layer=persistent_layer,
+          prefill_layer=prefill_layer,
+          logical_valid_mask=logical_valid_mask,
+      )
+    else:
+      # Global: standard prefix write (matches existing _set_cache).
+      p_len = prefill_layer['k'].shape[1]
+      new_dict[layer_name] = {
+          'k': persistent_layer['k'].at[:, :p_len].set(prefill_layer['k']),
+          'v': persistent_layer['v'].at[:, :p_len].set(prefill_layer['v']),
+          'positions': persistent_layer['positions'].at[:, :p_len].set(
+              prefill_layer['positions']
+          ),
+          'end_index': prefill_layer['end_index'],
+      }
+
+  return _cache_helper.Cache(new_dict)
+
+
+def _compact_local_window_layer(
+    *,
+    persistent_layer: dict,
+    prefill_layer: dict,
+    logical_valid_mask: jax.Array,
+):
+  """Compact a full-size prefill scratch into a window-sized ring buffer.
+
+  After prefill, `prefill_layer` is shape [B, P, num_kv_heads, head_dim] with
+  P = prefill_cache_length (the prompt bucket length, may be < or > W).
+  `persistent_layer` is shape [B, W, ...] with W = sliding_window_size.
+
+  We keep the last W valid logical slots per batch row, then place each token
+  at slot (absolute_position % W). Logical indices are stored only as metadata
+  for mapping the sampler's full logical attention mask. This distinction is
+  important for padded batches: a short row should retain its live local
+  context even when another row forced a much longer padded logical timeline.
+  """
+  W = persistent_layer['k'].shape[1]      # static
+  P = prefill_layer['k'].shape[1]         # static
+  B = persistent_layer['k'].shape[0]      # static
+
+  logical_valid_mask = logical_valid_mask[:, :P]
+  logical_indices = jnp.arange(P, dtype=jnp.int32)[None, :]
+
+  # Select the last W valid logical slots for each batch row. The rank-based
+  # selection avoids treating padding slots as local-cache residents.
+  valid_rank = jnp.cumsum(logical_valid_mask.astype(jnp.int32), axis=-1)
+  num_valid = valid_rank[:, -1]
+  first_kept_rank = jnp.maximum(0, num_valid - W)
+  keep = logical_valid_mask & (valid_rank > first_kept_rank[:, None])
+  selected_rank = jnp.clip(valid_rank - first_kept_rank[:, None] - 1, 0, W - 1)
+
+  batch_indices_p = jnp.arange(B)[:, None]
+  selected_logical = jnp.full((B, W), -1, dtype=jnp.int32)
+  selected_logical = selected_logical.at[
+      batch_indices_p, selected_rank
+  ].max(jnp.where(keep, logical_indices, -1))
+  selected_valid = selected_logical >= 0
+  safe_selected_logical = jnp.clip(selected_logical, 0, P - 1)
+
+  selected_k = jnp.take_along_axis(
+      prefill_layer['k'], safe_selected_logical[:, :, None, None], axis=1
+  )
+  selected_v = jnp.take_along_axis(
+      prefill_layer['v'], safe_selected_logical[:, :, None, None], axis=1
+  )
+  selected_pos = jnp.take_along_axis(
+      prefill_layer['positions'], safe_selected_logical, axis=1
+  ).astype(jnp.int32)
+
+  dst_phys = selected_pos % W
+  slots = jnp.arange(W, dtype=jnp.int32)
+  matches = (dst_phys[:, :, None] == slots[None, None, :])
+  matches = matches & selected_valid[:, :, None]
+  source_for_slot = jnp.argmax(matches, axis=1)
+  slot_valid = jnp.any(matches, axis=1)
+
+  out_k = jnp.take_along_axis(
+      selected_k, source_for_slot[:, :, None, None], axis=1
+  )
+  out_v = jnp.take_along_axis(
+      selected_v, source_for_slot[:, :, None, None], axis=1
+  )
+  out_pos = jnp.take_along_axis(selected_pos, source_for_slot, axis=1)
+  out_logical = jnp.take_along_axis(
+      selected_logical, source_for_slot, axis=1
+  )
+
+  return {
+      'k': jnp.where(slot_valid[:, :, None, None], out_k,
+                     jnp.zeros_like(out_k)),
+      'v': jnp.where(slot_valid[:, :, None, None], out_v,
+                     jnp.zeros_like(out_v)),
+      'positions': jnp.where(slot_valid, out_pos, -(10**9)),
+      'logical_index': jnp.where(slot_valid, out_logical, -1),
+      'valid': slot_valid,
+      'end_index': prefill_layer['end_index'],
+  }
 
 
 def _make_full_attention_mask(

--- a/gemma/gm/text/_prefill_test.py
+++ b/gemma/gm/text/_prefill_test.py
@@ -159,3 +159,110 @@ def test_full_attention_mask():
       ],
   )
 
+
+def test_local_window_compaction_uses_valid_tokens_and_positions():
+  batch_size = 2
+  window = 4
+  prefill_len = 8
+  persistent_layer = {
+      'k': jnp.zeros((batch_size, window, 1, 1), dtype=jnp.float32),
+      'v': jnp.zeros((batch_size, window, 1, 1), dtype=jnp.float32),
+      'positions': jnp.full((batch_size, window), -(10**9), dtype=jnp.int32),
+      'logical_index': jnp.full((batch_size, window), -1, dtype=jnp.int32),
+      'valid': jnp.zeros((batch_size, window), dtype=jnp.bool_),
+      'end_index': jnp.zeros((batch_size,), dtype=jnp.int32),
+  }
+  values = jnp.broadcast_to(
+      jnp.arange(prefill_len, dtype=jnp.float32)[None, :, None, None],
+      (batch_size, prefill_len, 1, 1),
+  )
+  prefill_layer = {
+      'k': values,
+      'v': values + 100,
+      # Row 1 models a short padded prompt sharing a long bucket with row 0:
+      # only logical slots 0, 1, 2 are real, and their positions are still
+      # live local context.
+      'positions': jnp.asarray(
+          [
+              [0, 1, 2, 3, 4, 5, 6, 7],
+              [0, 1, 2, 2, 2, 2, 2, 2],
+          ],
+          dtype=jnp.int32,
+      ),
+      'end_index': jnp.asarray([prefill_len, prefill_len], dtype=jnp.int32),
+  }
+  logical_valid_mask = jnp.asarray(
+      [
+          [1, 1, 1, 1, 1, 1, 1, 1],
+          [1, 1, 1, 0, 0, 0, 0, 0],
+      ],
+      dtype=jnp.bool_,
+  )
+
+  compact = _prefill._compact_local_window_layer(
+      persistent_layer=persistent_layer,
+      prefill_layer=prefill_layer,
+      logical_valid_mask=logical_valid_mask,
+  )
+
+  np.testing.assert_array_equal(
+      compact['logical_index'],
+      [
+          [4, 5, 6, 7],
+          [0, 1, 2, -1],
+      ],
+  )
+  np.testing.assert_array_equal(
+      compact['positions'],
+      [
+          [4, 5, 6, 7],
+          [0, 1, 2, -(10**9)],
+      ],
+  )
+  np.testing.assert_array_equal(
+      compact['valid'],
+      [
+          [1, 1, 1, 1],
+          [1, 1, 1, 0],
+      ],
+  )
+  np.testing.assert_array_equal(
+      compact['k'][..., 0, 0],
+      [
+          [4, 5, 6, 7],
+          [0, 1, 2, 0],
+      ],
+  )
+
+
+def test_local_window_prefill_scratch_restages_previous_cache():
+  persistent_layer = {
+      'k': jnp.asarray([[[[10]], [[11]], [[12]], [[13]]]], dtype=jnp.float32),
+      'v': jnp.asarray([[[[20]], [[21]], [[22]], [[23]]]], dtype=jnp.float32),
+      'positions': jnp.asarray([[2, 3, -(10**9), 1]], dtype=jnp.int32),
+      'logical_index': jnp.asarray([[6, 7, -1, 5]], dtype=jnp.int32),
+      'valid': jnp.asarray([[1, 1, 0, 1]], dtype=jnp.bool_),
+      'end_index': jnp.asarray([8], dtype=jnp.int32),
+  }
+
+  scratch = _prefill._make_local_window_prefill_scratch_layer(
+      persistent_layer=persistent_layer,
+      prefill_cache_length=10,
+  )
+
+  assert 'logical_index' not in scratch
+  assert 'valid' not in scratch
+  np.testing.assert_array_equal(scratch['end_index'], [8])
+  np.testing.assert_array_equal(
+      scratch['k'][0, :, 0, 0],
+      [0, 0, 0, 0, 0, 13, 10, 11, 0, 0],
+  )
+  np.testing.assert_array_equal(
+      scratch['v'][0, :, 0, 0],
+      [0, 0, 0, 0, 0, 23, 20, 21, 0, 0],
+  )
+  np.testing.assert_array_equal(
+      scratch['positions'][0],
+      [-(10**9), -(10**9), -(10**9), -(10**9), -(10**9),
+       1, 2, 3, -(10**9), -(10**9)],
+  )

--- a/gemma/gm/text/_sampler_loop.py
+++ b/gemma/gm/text/_sampler_loop.py
@@ -161,13 +161,18 @@ class SamplerLoop:
       # Keep going while we have not reached the maximum number of tokens, and
       # at least one of the samples is not done.
 
+      # Use the LOGICAL cache length (the sampler's static `cache_length`),
+      # not any layer's physical shape. With LOCAL_WINDOW caches, layer 0 is
+      # window-sized (e.g. 512), but generation should continue until the
+      # GLOBAL cache fills.
+      cache_full = state.used_cache_length >= self.cache_length - 1
       return (
           # We predicted too many tokens.
           (state.step < max_new_tokens)
           # All batch have yield the `<end_of_turn>` token.
           & ~jnp.all(state.done)
-          # End if the cache is full.
-          & ~state.cache_info.is_full
+          # End if the logical cache is full.
+          & ~cache_full
       )
 
     state = jax.lax.while_loop(cond_fn, step_fn, state)
@@ -207,8 +212,9 @@ class SamplerLoop:
     """Streaming sampling function."""
     # Sample autoregressively.
     for _ in range(max_new_tokens):
-      # Exit if the cache is full.
-      if jnp.all(state.done) or state.cache_info.is_full:
+      # Exit if the logical cache is full.
+      cache_full = state.used_cache_length >= self.cache_length - 1
+      if jnp.all(state.done) or cache_full:
         break
 
       state = self._sample_step(

--- a/gemma/gm/utils/_cache_helper.py
+++ b/gemma/gm/utils/_cache_helper.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
+import os
 
 from etils import epy
 import flax
@@ -26,6 +28,77 @@ from kauldron.ktyping import Bool, Int  # pylint: disable=g-multiple-import
 
 _Slice = slice | int
 _GetItem = _Slice | tuple[_Slice, ...]
+
+
+class KVCacheMode(enum.Enum):
+  """KV cache allocation/storage policy.
+
+  - LEGACY: every layer gets a `[B, cache_length, num_kv_heads, head_dim]`
+    buffer. Default. Backwards-compatible with all existing call sites.
+  - LOCAL_WINDOW: Gemma 4 LOCAL_SLIDING layers get a `[B, sliding_window_size,
+    num_kv_heads, head_dim]` ring-buffer cache plus per-slot `logical_index`
+    and `valid` metadata; GLOBAL layers stay at `cache_length`. Prefill still
+    uses a full-size scratch cache and compacts post-prefill, so prefill
+    semantics are unchanged.
+  """
+
+  LEGACY = 'legacy'
+  LOCAL_WINDOW = 'local_window'
+
+  @classmethod
+  def from_env(cls, default: KVCacheMode | None = None) -> KVCacheMode:
+    """Read mode from `GEMMA_KV_CACHE_MODE` env var, with a default fallback.
+
+    Used so we can A/B test without changing call sites.
+    """
+    if default is None:
+      default = cls.LEGACY
+    raw = os.environ.get('GEMMA_KV_CACHE_MODE', '').strip().lower()
+    if not raw:
+      return default
+    for m in cls:
+      if m.value == raw:
+        return m
+    raise ValueError(
+        f'Unknown GEMMA_KV_CACHE_MODE={raw!r}. Valid: '
+        f'{[m.value for m in cls]}'
+    )
+
+
+class KVPrefillMode(enum.Enum):
+  """KV cache prefill strategy.
+
+  - LEGACY_SCRATCH: prefill computes against a full logical scratch cache.
+    LOCAL_WINDOW persistent caches are compacted after prefill. This is the
+    correctness-first mode and the only implemented mode today.
+  """
+
+  LEGACY_SCRATCH = 'legacy_scratch'
+
+  @classmethod
+  def from_env(cls, default: KVPrefillMode | None = None) -> KVPrefillMode:
+    """Read mode from `GEMMA_KV_PREFILL_MODE` env var."""
+    if default is None:
+      default = cls.LEGACY_SCRATCH
+    raw = os.environ.get('GEMMA_KV_PREFILL_MODE', '').strip().lower()
+    if not raw:
+      return default
+    for m in cls:
+      if m.value == raw:
+        return m
+    raise ValueError(
+        f'Unknown GEMMA_KV_PREFILL_MODE={raw!r}. Valid: '
+        f'{[m.value for m in cls]}'
+    )
+
+
+def is_local_window_layer(layer_data: dict) -> bool:
+  """Detect whether a layer's cache uses the local-window ring layout.
+
+  We use duck-typing on the metadata fields rather than a separate enum so
+  the cache pytree itself stays self-describing.
+  """
+  return 'logical_index' in layer_data and 'valid' in layer_data
 
 
 @flax.struct.dataclass
@@ -42,9 +115,15 @@ class Cache:
 
   @property
   def total_cache_length(self) -> int:
-    layer_data = next(iter(self.cache.values()))
-    _, l, _, _ = layer_data['k'].shape
-    return l
+    """Max physical seq dim across all layers.
+
+    For LEGACY caches every layer has the same shape, so this returns
+    `cache_length`. For LOCAL_WINDOW caches the global layers carry the full
+    `cache_length` while local layers are window-sized; the max reflects the
+    global (logical) cache length, which is what callers want for mask
+    sizing and is_full semantics.
+    """
+    return max(d['k'].shape[1] for d in self.cache.values())
 
   def __getitem__(self, key: _GetItem) -> Cache:
     """Get a slice of the cache.
@@ -140,9 +219,22 @@ def _map_cache_layer(cache, fn, **kwargs):
 
 
 def _slice_cache(layer_data, *, key: _GetItem):
+  """Slice the cache along (batch, seq) for prefill.
+
+  For LOCAL_WINDOW layers the seq-axis slice key may exceed the physical
+  cache size (because prefill_cache_length follows the global cache_length).
+  Python slicing clamps gracefully, but we leave the local-window slot
+  unchanged here because prefill uses a separate scratch cache (see
+  `_prefill._make_scratch_cache_for_local_window`) so this slice path is
+  never traversed for LOCAL_WINDOW layers in practice.
+  """
   layer_data['k'] = layer_data['k'][*key, :, :]
   layer_data['v'] = layer_data['v'][*key, :, :]
   layer_data['positions'] = layer_data['positions'][*key]
+  if 'logical_index' in layer_data:
+    layer_data['logical_index'] = layer_data['logical_index'][*key]
+  if 'valid' in layer_data:
+    layer_data['valid'] = layer_data['valid'][*key]
   return layer_data
 
 
@@ -152,6 +244,14 @@ def _set_cache(layer_data0, layer_data1, *, key):
   layer_data0['positions'] = (
       layer_data0['positions'].at[*key].set(layer_data1['positions'])
   )
+  if 'logical_index' in layer_data0 and 'logical_index' in layer_data1:
+    layer_data0['logical_index'] = (
+        layer_data0['logical_index'].at[*key].set(layer_data1['logical_index'])
+    )
+  if 'valid' in layer_data0 and 'valid' in layer_data1:
+    layer_data0['valid'] = (
+        layer_data0['valid'].at[*key].set(layer_data1['valid'])
+    )
   return layer_data0
 
 


### PR DESCRIPTION
# Gemma JAX KV Cache: Memory & Sharding Design Proposal

**Author:** Karl (with Claude Code assistance)
**Status:** Updated after design review
**Target:** `github.com/google-deepmind/gemma` (this repo)
**Date:** 2026-05-09
**Related code paths:**
- [`gemma/gm/text/_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py)
- [`gemma/gm/text/_chat_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py)
- [`gemma/gm/text/_gemma4_sampler.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py)
- [`gemma/gm/text/_prefill.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py)
- [`gemma/gm/text/_sampler_loop.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler_loop.py)
- [`gemma/gm/nn/gemma4/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py)
- [`gemma/gm/nn/gemma4/_modules.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py)
- [`gemma/gm/nn/gemma4/_transformer.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py)
- [`gemma/gm/utils/_cache_helper.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py)

---

## 1. Problem Statement

The `gm.text.ChatSampler` / `gm.text.Gemma4Sampler` inference path is
substantially less HBM-efficient than necessary on multi-chip TPU slices,
specifically for the Gemma 4 model family which uses hybrid
local-sliding + global attention. Two independent issues compound:

**Problem A — Eager, uniform cache allocation across all layers.**
At sampler construction time (more precisely at the start of every
non-multi-turn prefill call), the cache is allocated as a fixed
`[batch, cache_length, num_kv_heads, head_dim]` buffer **identically
sized on every layer**, including layers whose attention type is
`LOCAL_SLIDING` and which only ever read the most recent
`sliding_window_size` tokens during causal decode
([`gemma4/_modules.py:343-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L343-L349)
masks all positions outside the window). For a Gemma 4 model that uses a
5L:1G pattern (E4B has 35 local + 7 global; 31B has 50 local + 10 global;
26B-A4B has 25 local + 5 global), most of the per-layer cache budget is
zeroed bytes that the attention mask discards. The waste fraction grows
linearly with `cache_length` until at long contexts the cache is
dominated by guaranteed-unread bytes.

**Problem B — Cache is replicated across the device slice.**
At all current call sites
([`gemma4/_transformer.py:412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L412),
[`_transformer.py:329`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_transformer.py#L329),
[`gemma3n/_transformer.py:370`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_transformer.py#L370))
the cache pytree is passed to
`kd.sharding.with_sharding_constraint(cache, sharding)` with no
intrinsic, model-aware partition spec. The user-facing samplers
(`Sampler`, `Gemma4Sampler`, `ChatSampler`) accept a `sharding=` kwarg
but the documented usage path
([`colabs/sharding.ipynb`](https://github.com/google-deepmind/gemma/blob/main/colabs/sharding.ipynb))
does not pass one. With `sharding=None` the constraint is a no-op and
the cache lives wherever the active mesh / JIT default puts it. With
FSDP-sharded params and no explicit cache sharding, the cache gets
**replicated across every chip** — same memory cost on every chip in
the slice, scaling 1× rather than 1/N×.

The combination is a multiplicative loss: every chip pays for cache
slots that are never read. On memory-constrained slices (16 GB / chip
on TPU v5e) it is the dominant blocker for running the larger Gemma 4
variants (31B, 26B-A4B) at any usable context length, and a soft
blocker for E2B/E4B at long contexts (≥16K).

### 1.1. Empirical evidence

Two scripts ([`examples/cache_audit.py`](./examples/cache_audit.py) and
[`examples/cache_probe.py`](./examples/cache_probe.py), included in
this proposal) collect the following data on a v5e-4 slice (4 chips,
16 GB HBM each, FSDP-sharded params):

**Cache audit, Gemma4_E4B (35 LOCAL_SLIDING + 7 GLOBAL layers,
`num_kv_heads=2`, `head_dim=256` local / 512 global,
`sliding_window_size=512`):**

| `cache_length` | Total cache bytes | LOCAL bytes | GLOBAL bytes | Ratio vs L=256 |
|---:|---:|---:|---:|---:|
|   256 |   24.54 MiB |  17.53 MiB |   7.01 MiB | 1.00× |
| 4 096 |  392.66 MiB | 280.55 MiB | 112.11 MiB | 16.00× |
|16 384 | 1 506.11 MiB | 1 100 MiB | 448 MiB | 64.00× |

The ratio is **exactly linear in `cache_length` across every layer**,
including all 35 local-sliding layers. With a `sliding_window_size=512`,
the local layers only ever read `<= 512` slots; at `cache_length=16384`
the local-attention storage is **31× over-allocated per local layer**
(15 872 unread slots for every 512 read).

**Runtime probe, Gemma4_E4B, ChatSampler with FSDP-sharded params,
single chat() turn (~25 output tokens):**

| Metric | L=4 096 | L=16 384 |
|---|---:|---:|
| HBM after params load (per chip) | 7.81 GiB | 7.81 GiB |
| Peak HBM during chat (chip 0) | 9.46 GiB | 14.04 GiB |
| Peak HBM during chat (chips 1-3) | 9.37 GiB | 13.95 GiB |
| **Per-chip peak Δ** | **+1.6 GiB** | **+6.2 GiB** |
| Per-chip post-chat Δ (steady state) | +800 MiB | +3.08 GiB |

Interpretation:

1. The peak deltas are roughly equal across all 4 chips (chip 0 is only
   ~90 MiB above the others). This **confirms Problem B with replication
   semantics**: every chip absorbs the full cache cost.
2. The post-chat steady-state delta of ~800 MiB at L=4096 is roughly
   **2× the logical cache size** (392 MiB). The extra ~400 MiB is the
   `last_state.cache` held by `ChatSampler` plus a transient second
   copy created by the functional update in `_merge_cache`
   ([`_prefill.py:357-366`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L357-L366)).
3. At L=16384 the per-chip peak exceeds 14 GiB out of a 15.75 GiB chip
   limit. With ~6 GiB of headroom for activations/intermediate buffers
   already consumed, this is the regime where small jit-time
   re-allocations OOM — matching the originally reported
   "32 MB allocation fails with chip 0 at near-zero free" symptom on
   the bigger models (31B / 26B-A4B).

### 1.2. Why this matters for production-style usage on TPU v5e

The repo's stated audience for this sampler is research/experimentation
([`gm.text.Sampler` docstring](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py#L86)
explicitly recommends `gm.text.ChatSampler` "for most use cases"). But
the sampler is the only ergonomic in-repo path to evaluate Gemma 4 on a
TPU slice without standing up a separate inference engine. Closing
even half the gap between the current implementation and a
production-quality KV cache layout (à la MaxText / JetStream) makes
the official sampler a viable evaluation tool for the larger Gemma 4
variants on commodity TPU slices.

### 1.3. Out of scope

The following are intentionally NOT in scope for this proposal:

- **PagedAttention / vLLM-style block-table caches.** Significant
  surgery (block tables, Pallas gather kernels, ragged attention math).
  Only a clear win for batched, multi-tenant serving with
  heterogeneous request lengths. For a research sampler with batch=1
  the eager-buffer approach is fine *once* Problems A and B are fixed.
- **Quantized KV cache** (int8 / fp8). Independent axis of
  improvement; can be layered on top of either fix.
- **Cross-sampler refactor** (unifying `Sampler` / `Gemma4Sampler` /
  `ChatSampler`). This proposal touches their shared dependencies but
  preserves their public interfaces.

---

## 2. Code Archaeology

### 2.1. Cache data structure

The cache is a **plain `dict[str, dict[str, jax.Array]]`** keyed by
`f"layer_{i}"`, with no axis-aware annotations:

```
type alias:  Cache = dict[str, _modules.LayerCache]
type alias:  LayerCache = dict[str, jax.Array]
```

Defined at
[`gemma/gm/nn/_config.py:28`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_config.py#L28)
(legacy) and
[`gemma/gm/nn/gemma4/_config.py:29`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L29)
(Gemma 4). Per layer, four arrays:

| Field | Shape | Dtype | Role |
|---|---|---|---|
| `'k'` | `[B, cache_size, num_kv_heads, head_dim]` | bf16 | key cache |
| `'v'` | `[B, cache_size, num_kv_heads, head_dim]` | bf16 | value cache |
| `'positions'` | `[B, cache_size]` | int32 | per-slot RoPE position (used by sliding mask) |
| `'end_index'` | `[B]` | int32 | write pointer (mod cache_size) |

A thin slicing wrapper exists
([`_cache_helper.Cache`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L31-L89))
but it just wraps the dict — it doesn't change the underlying layout.

### 2.2. Allocation and sharding

**Single-shot allocation per first-turn `sample()` / `chat()` call.**
The full call chain for Gemma 4:

1. User → `Gemma4Sampler.sample()` /
   `ChatSampler.chat()` ([`_chat_sampler.py:261`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L261)).
2. → `_prefill.prefill(... cache_length=self.cache_length, sharding=sharding)` ([`_gemma4_sampler.py:206`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py#L206)).
3. → `_get_or_init_cache()` ([`_prefill.py:283-307`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L283-L307)).
4. → `model.init_cache(...)` ([`_prefill.py:295-300`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L295-L300)).
5. → `Gemma4Transformer.init_cache` ([`gemma4/_transformer.py:399-412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L399-L412), `nn.jit`-decorated, static_argnames includes `cache_length`, `sharding`, etc.).
6. → `TransformerConfig.init_cache` ([`gemma4/_config.py:157-193`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L157-L193)).
7. → `_modules.Attention.init_cache` ([`gemma4/_modules.py:397-417`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L397-L417)) — `jnp.zeros(...)` per layer.

The sharding plumbing is a single
`kd.sharding.with_sharding_constraint(cache, sharding)` over the entire
pytree at
[`gemma4/_transformer.py:412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L412):

```python
return kd.sharding.with_sharding_constraint(cache, sharding)
```

If the user does not pass a `sharding=` argument (the documented
pattern), this is a no-op. The cache then takes the JAX default
placement, which inside an active FSDP mesh is **replicated** (as
confirmed by the runtime probe).

**`cache_length` source.** A user-tunable field on the sampler, default
4096
([`_sampler.py:137`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler.py#L137),
[`_gemma4_sampler.py:76`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_gemma4_sampler.py#L76),
[`_chat_sampler.py:127`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L127)).
Used as a single integer argument applied uniformly to every layer in
[`gemma4/_config.py:171-192`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L171-L192).

**Allocation frequency.** Once per first-turn `sample()` / `chat()`. In
multi-turn mode, the cache is reused across turns
([`_prefill.py:301-303`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L301-L303):
`cache = prev_turns.cache`).

### 2.3. The local-sliding waste, exposed

The structural location of Problem A is
[`gemma4/_config.py:171-192`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L171-L192):

```python
for i, attn_type in enumerate(self.attention_types):
  if (attn_type == _modules.AttentionType.GLOBAL
      and self.global_key_size is not None):
    cache[f'layer_{i}'] = _modules.Attention.init_cache(
        cache_length,                                            # uniform
        self.num_global_kv_heads if self.num_global_kv_heads
        else self.num_kv_heads,
        self.global_key_size,
        batch_size, dtype)
  else:
    cache[f'layer_{i}'] = _modules.Attention.init_cache(
        cache_length,                                            # uniform
        self.num_kv_heads,
        self.head_dim,
        batch_size, dtype)
```

The two branches differ in `num_kv_heads` and `head_dim` only. The
`cache_length` argument is identical for global and local-sliding
layers. The mask in
[`gemma4/_modules.py:338-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L338-L349)
already discards everything outside the window — no slot beyond
`sliding_window_size` is ever attended to in a local-sliding layer.

The same pattern exists in
[`gemma3n/_config.py:178-194`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_config.py#L178-L194).
The original Gemma 1-3 path
([`gemma/gm/nn/_config.py:120-142`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_config.py#L120-L142))
is uniform but Gemma 1-3 don't have hybrid attention, so it's not a
loss there.

### 2.4. Decode-step writes

Each decode step writes one slot via `dynamic_update_slice` /
`array.at[...].set(...)` into the pre-allocated buffer; there is no
physical growth. The write index uses modular wrap (`end_index %
cache_size` at
[`gemma4/_modules.py:304`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L304))
but the loop halts before the wrap matters — `cond_fn` checks
`is_full = end_index >= total_cache_length - 1`
([`_cache_helper.py:86-89`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L86-L89),
[`_sampler_loop.py:160-171`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_sampler_loop.py#L160-L171)).
The mod-wrap is defensive, not load-bearing.

### 2.5. The "is_full" first-layer assumption

`Cache.total_cache_length` reads `next(iter(self.cache.values()))['k'].shape[1]`
([`_cache_helper.py:43-47`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L43-L47)).
It assumes every layer has the same cache length. **Any change that
introduces per-layer cache sizes must update this method** to either
(a) return the max across layers, or (b) be replaced with per-layer
queries.

---

## 3. Proposed Changes

This proposal includes **two independent but composable changes**,
ranked by HBM impact at long context. Either can be merged
independently.

### 3.1. Change A: right-size LOCAL_SLIDING cache to the window

**Summary.** Cap each local-sliding layer's cache size at
`min(cache_length, sliding_window_size)`. Global layers retain the
full `cache_length`.

The implementation should be toggled with `KVCacheMode`, defaulting to
`LEGACY`, and prefill should expose `KVPrefillMode.LEGACY_SCRATCH`
through `GEMMA_KV_PREFILL_MODE=legacy_scratch` so benchmarks can record
the active prefill strategy explicitly.

**Why not "+1".** The window mask at
[`gemma4/_modules.py:50-51`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L50-L51)
uses strict bounds: `cache_position > position - sliding_window_size`
and `cache_position < position + sliding_window_size`. With the normal
causal mask during decode, that admits the current token plus the
previous `sliding_window_size - 1` tokens. The persistent causal local
cache therefore needs exactly `sliding_window_size` slots, not
`sliding_window_size + 1`.

**HBM saved (E4B, batch=1, bf16, per chip if currently replicated):**

| `cache_length` | Current local cache | After change | Savings per chip |
|---:|---:|---:|---:|
|   4 096 | 280 MiB |  35 MiB | **245 MiB** |
|  16 384 | 1.10 GiB |  35 MiB | **1.07 GiB** |
|  32 768 | 2.19 GiB |  35 MiB | **2.16 GiB** |
| 131 072 | 8.75 GiB |  35 MiB | **8.72 GiB** |

(Local-cache size becomes constant once `cache_length >= window`. The
~35 MiB figure for E4B is `35 layers x 1 x 512 x 2 x 256 x 2(k+v) x 2 B`.)

For 31B (50 local + 10 global, sliding_window=1024, num_kv_heads=16
local / 4 global): savings scale by ~ `50/35 × 16/2 ≈ 11×` versus E4B
in absolute terms.

**Implementation.**

Patch [`gemma/gm/nn/gemma4/_config.py:157-193`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L157-L193):

```python
def init_cache(self, batch_size, dtype=jnp.bfloat16, *, cache_length):
  if cache_length is None:
    raise ValueError('Missing `cache_length=` kwarg when calling `init_cache()`.')

  # NEW: Local-sliding layers only ever read sliding_window_size slots.
  # Cap their cache to that to avoid allocating bytes that are guaranteed
  # to be masked out at attention time.
  local_cache_length = (
      min(cache_length, self.sliding_window_size)
      if self.sliding_window_size is not None
      else cache_length
  )

  cache: Cache = {}
  for i, attn_type in enumerate(self.attention_types):
    if (attn_type == _modules.AttentionType.GLOBAL
        and self.global_key_size is not None):
      cache[f'layer_{i}'] = _modules.Attention.init_cache(
          cache_length,                                  # full
          self.num_global_kv_heads or self.num_kv_heads,
          self.global_key_size,
          batch_size, dtype)
    else:
      cache[f'layer_{i}'] = _modules.Attention.init_cache(
          local_cache_length,                            # NEW: window-capped
          self.num_kv_heads,
          self.head_dim,
          batch_size, dtype)
  return cache
```

Do Gemma 4 first. Mirror into Gemma 3n only after the Gemma 4 path has
passed equivalence tests, because Gemma 4 is the critical long-context
path and already exercises heterogeneous local/global head dimensions.

**Required collateral changes.** Per-layer cache sizes now vary, so
several pieces of code that assume a uniform layer cache need to be
fixed:

1. **`Cache.total_cache_length`**
   ([`_cache_helper.py:43-47`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L43-L47)).
   Currently reads layer 0's `k.shape[1]`. Must return either the max
   across layers or be replaced with a per-layer query. Recommendation:
   `return max(d['k'].shape[1] for d in self.cache.values())`. The
   `is_full` semantic at line 86-89 should then use the max — i.e.,
   "stop sampling when the *largest* (typically global) cache is full",
   not when the local cache fills up at the sliding-window boundary.

2. **Full logical masks plus physical local-slot mapping.**
   `SamplingState.attention_mask_for_step` should continue to build a
   mask at the full logical cache length. Local attention cannot rely
   on implicit einsum truncation once the local cache is ring-buffered:
   physical slot `s` no longer means logical token `s`. Local cache
   entries need `logical_index` and `valid` metadata, and
   `Attention.__call__` must gather the logical mask onto physical
   slots before applying the sliding mask.

3. **Prefill prompt longer than `sliding_window_size`.** Do not simply
   pass a window-sized local cache into prefill. The attention module
   writes K/V into the supplied cache before computing attention; a
   window-sized prefill cache would overwrite early prompt K/V before
   later prompt tokens and later global layers can use them. The safe
   first implementation is:
   - Allocate the persistent decode cache with local layers sized to
     `sliding_window_size`.
   - Build a full-size prefill scratch cache for local layers, with no
     local-window metadata, so prefill attention has legacy semantics.
   - Run `model.apply` against the scratch.
   - Compact the returned local layers back into the persistent ring
     cache.
   - Copy returned global layers into the persistent global cache.

4. **Compaction must be per batch row.** A naive "last W logical slots"
   compaction is wrong for padded batches: a short row can have live
   local-context prompt tokens near logical slots 0..N while another
   row forced the bucket to a much larger logical length. The safe rule
   is to keep the last W valid logical slots per batch row, place each
   by `absolute_position % W`, and store the original logical slot in
   `logical_index` for future mask gathers.

5. **Decode writes must evict by position, not padded logical index.**
   Local-window decode writes should use `segment_pos % window` for the
   physical slot and store `end_index + arange(seq_len)` only as
   `logical_index` metadata. This preserves the local sliding window
   for padded rows while keeping the sampler's full logical mask
   intact.

**Risks.**

- **Correctness of scratch compaction.** Need to verify that ROPE
  positions, `cache_positions`, `logical_index`, and `valid` are
  correct after the prefill+merge dance. The sliding mask at
  [`gemma4/_modules.py:343-349`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L343-L349)
  uses `cache_positions` (the actual position stored at each slot), so
  as long as we write the correct `positions` alongside the K/V values
  and gather the logical mask through `logical_index`, the ring-buffer
  math handles wraparound. Add regression tests for prompt lengths
  `< window`, `== window`, and `> window`, plus padded batches where
  one row is much shorter than the bucket length.
- **Recompilation.** Changing layer shapes triggers a JIT recompile.
  Acceptable, one-time.
- **`is_full` semantics.** Today the loop stops when *layer 0* fills.
  Layer 0 is local-sliding in every Gemma 4 variant, so today the
  loop currently stops when the local cache fills (around step 512), which
  is *the wrong stopping condition* for global layers. Today this
  isn't observed because users typically pick `cache_length ≥ 4096 ≫
  sliding_window` and don't notice. After this change, with the local
  cache *physically* sized to the window, the same `is_full` would fire
  at step 512 always. The sampler loop must stop on the logical
  `SamplerLoop.cache_length` or `state.full_attention_mask.shape[-1]`,
  not on any local layer's physical shape.

**Test plan.**

1. **Unit test:** for every Gemma 4 variant, verify
   `model.init_cache(cache_length=4096)` produces local-layer cache
   shapes of `[1, sliding_window_size, num_kv_heads, head_dim]` and
   global-layer caches of `[1, 4096, num_global_kv_heads or
   num_kv_heads, global_key_size or head_dim]`.
2. **Numerical equivalence:** run a fixed prompt with a fixed RNG seed
   through `ChatSampler.chat()` before and after the change. Output
   tokens should match for greedy sampling. Logits only need BF16
   tolerance because compacting/gathering can change reduction order.
3. **HBM regression:** run [`examples/cache_probe.py`](./examples/cache_probe.py)
   at L=4096 and L=16384 and verify the per-chip steady-state delta
   drops as predicted in §3.1's table.

### 3.2. Change B: cache sharding contract

**Summary.** Add a model-level contract that exposes a
`PartitionSpec` pytree for the cache, computed from the model config
and the active mesh. Apply it inside `init_cache` regardless of
whether the user passed a `sharding=` kwarg. For batch=1 decode, shard
along `num_kv_heads` when the head count is divisible by the mesh's TP
axis size; replicate otherwise.

**Why this and not "expose more knobs to the user".** Today's
`sharding=` kwarg is a generic `kd.sharding.ShardingTree`. The user has
no documented way to construct one for the cache (no example exists in
the repo, and `kd.sharding.FSDPSharding()` — the only documented
sharding helper — shards axis 0, which is `batch` in the cache, which
is 1 at decode time). The cache *is* a model-internal data structure
with a model-internal layout; the model is the right place to know how
it should partition.

**HBM saved (E4B at L=4096, currently 392 MiB replicated on every chip
of a 4-chip slice = 1.57 GiB total slice HBM):**

- E4B (`num_kv_heads=2`, 4 chips → TP=2 + replicate=2): each chip
  holds 1/2 of the cache → 196 MiB / chip → **196 MiB saved per chip**
  (vs. 392 MiB replicated). Total slice HBM drops from 1.57 GiB → 784
  MiB.
- 31B (`num_kv_heads=16` local, 4 global, 4 chips → TP=4): each chip
  holds 1/4 → **3/4 saved per chip** for local layers; global layers
  shard exactly 4-ways. Roughly 4× per-chip cache reduction.
- 26B-A4B (`num_kv_heads=8` local, 2 global, 4 chips → TP=4 for local,
  TP=2+rep for global): roughly 4× for local, 2× for global.
- E2B (`num_kv_heads=1`, can't shard heads): no win — falls back to
  replication (current behavior). Acceptable.

Composes multiplicatively with Change A. Combined for 31B at
`cache_length=32768`:

- Today: ~30 GiB replicated, OOMs immediately.
- Change A only: ~4 GiB replicated.
- Change B only: ~7-8 GiB per chip.
- Change A + B: ~1 GiB per chip — fits with room for activations.

**Implementation.**

Add a method to `TransformerConfig` (Gemma 4) — and analogous changes
to Gemma 1-3 and Gemma 3n configs — that returns a cache partition
spec given the active mesh:

```python
def cache_partition_spec(self, mesh, *, tp_axis: str = 'tensor'):
  """Return a PartitionSpec pytree for the cache.

  Shards k/v along num_kv_heads when the head count is divisible by the
  TP axis size; otherwise leaves replicated. Other cache fields
  (positions, end_index) are always replicated.
  """
  from jax.sharding import PartitionSpec as P, NamedSharding
  if tp_axis not in mesh.axis_names:
    # No TP axis — replicate everything.
    pspec_kv = P()
    pspec_pos = P()
    pspec_end = P()
  else:
    tp_size = mesh.shape[tp_axis]
    # Replicate fallback if any layer's heads don't divide evenly.
    def kv_spec(num_heads):
      return P(None, None, tp_axis, None) if num_heads % tp_size == 0 else P()
    # We build a per-layer spec because num_kv_heads can vary.
    ...

  spec_tree = {}
  for i, attn_type in enumerate(self.attention_types):
    if attn_type == _modules.AttentionType.GLOBAL and self.global_key_size:
      heads = self.num_global_kv_heads or self.num_kv_heads
    else:
      heads = self.num_kv_heads
    spec_tree[f'layer_{i}'] = {
        'k': NamedSharding(mesh, kv_spec(heads)),
        'v': NamedSharding(mesh, kv_spec(heads)),
        'positions': NamedSharding(mesh, P()),
        'end_index': NamedSharding(mesh, P()),
    }
  return spec_tree
```

Then in
[`gemma/gm/nn/gemma4/_transformer.py:399-412`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_transformer.py#L399-L412):

```python
def init_cache(self, *, batch_size, dtype, cache_length, sharding=None):
  cache = self.config.init_cache(
      batch_size=batch_size, dtype=dtype, cache_length=cache_length)

  # NEW: derive a model-aware default sharding from the active mesh,
  # use it unless the user passed an explicit sharding.
  if sharding is None:
    mesh = _get_active_mesh()  # via jax.sharding.get_abstract_mesh() or similar
    if mesh is not None:
      sharding = self.config.cache_partition_spec(mesh)

  return kd.sharding.with_sharding_constraint(cache, sharding)
```

Also: add `with_sharding_constraint` after every per-step cache write
in `Attention.__call__` so the per-step `dynamic_update_slice` /
`array.at[...].set(...)` doesn't all-gather the result back to a
replicated layout. Locations:
- Gemma 4: [`gemma4/_modules.py:307-316`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_modules.py#L307-L316).
- Gemma 1-3: [`_modules.py:213-238`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/_modules.py#L213-L238).
- Gemma 3n: corresponding section in `gemma3n/_modules.py`.

**Risks.**

- **Mesh discovery.** Inside `nn.jit init_cache`, getting hold of "the
  active mesh" requires either (a) requiring the user to pass it
  explicitly, (b) using `jax.sharding.get_abstract_mesh()` (modern JAX),
  or (c) inferring it from the params via `jax.tree.leaves(params)[0].sharding.mesh`.
  Recommendation: (c), because it ensures the cache mesh matches the
  param mesh — same TP axis, same chip ordering — and (c) doesn't
  require any change to the public sampler API.
- **Per-step all-reduce.** With cache sharded by heads and queries
  replicated, the per-step attention op is `jnp.einsum('BTNH,BSNH->BTNS', q, k_sharded)`
  which produces a `BTNS` result with `N` sharded — fine, no reduce
  needed yet — and then `'BTNS,BSNH->BTNH'` produces a `BTNH` with `N`
  sharded. The output projection `'BTNH,NHD->BTD'` reduces over `N`,
  triggering an all-reduce. On v5e this is bandwidth-bound by ICI;
  empirical cost should be small (≪ 1 ms / step) but must be measured.
- **Non-divisible head counts.** E4B's `num_kv_heads=2` on a 4-chip
  slice → TP=2, replicate=2 (the audit script confirms this works).
  E2B's `num_kv_heads=1` → fall back to replication. The proposed
  helper handles both via the `kv_spec(heads)` divisibility check.
- **Backward compatibility.** Today the user can pass a
  `sharding=`. We should preserve that as an override: if the user
  passed an explicit non-`None` sharding, do not auto-derive. This
  keeps the existing API contract and lets advanced users override.

**Test plan.**

1. **Audit:** [`examples/cache_audit.py --variant {e4b,31b,26b_a4b}
   --shard heads`](./examples/cache_audit.py) already exists; verify
   the auto-shard logic in `init_cache` produces the same
   `NamedSharding(..., P(None, None, 'tensor', None))` on k/v that the
   audit script's `--shard heads` mode produces.
2. **HBM regression:** [`examples/cache_probe.py`](./examples/cache_probe.py)
   should show **per-chip peak deltas drop by ~TP×** for E4B/31B.
   E4B at L=4096 should drop from 1.6 GiB peak / chip to ~800 MiB
   peak / chip. 31B at L=4096 should drop from ~3.7 GiB peak (today)
   to ~900 MiB peak.
3. **Numerical equivalence:** logit-level comparison before/after the
   change for a fixed prompt and seed. Sharding does not change math.
4. **Compile-time / step-time microbenchmark:** measure decode steps/sec
   before and after on E4B at L=4096. Acceptance: ≤ 5% slowdown from
   the per-step all-reduce on a 4-chip v5e slice.

### 3.3. Out of scope but worth noting: the transient 2× cache copy

The runtime probe shows a steady-state delta of ~800 MiB at L=4096 —
about 2× the logical 392 MiB cache. The extra copy is created in
`_merge_cache` at
[`_prefill.py:357-366`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py#L357-L366):

```python
return full_cache.at[:, : prefill_cache.total_cache_length].set_kv(prefill_cache)
```

`Cache.at[].set_kv()` uses `jnp.ndarray.at[...].set(...)` semantics
([`_cache_helper.py:113-119`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L113-L119),
[`_cache_helper.py:149-155`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py#L149-L155)),
which is functional. Without `donate_argnums` on the surrounding jit,
JAX may keep both the old and new buffers alive briefly, causing a
~2× transient. After the merge, `last_state.cache` retains the
*new* buffer; the old `full_cache` should be garbage-collected. The
fact that the steady-state delta is 2× suggests the old buffer is
still being held — likely because it's the input to `_merge_cache`
inside the JITted prefill, and JAX keeps it alive until the prefill
function returns.

This isn't part of this proposal, but a follow-up could:
- Donate the input cache buffer in the prefill jit
  (`jax.jit(prefill_fn, donate_argnums=...)`).
- Or restructure prefill to write directly into `full_cache` without
  the intermediate small-cache prefill + merge.

Estimated savings: an additional ~1× cache (cuts the per-chip
steady-state delta from 2×cache to 1×cache).

### 3.4. Stack rank

If only one change can be merged: **Change A**. It's smaller, safer,
benefits every Gemma 4 variant including E2B, and saves the most
absolute bytes at long contexts. Change B has a hard ceiling on E2B
(`num_kv_heads=1` is not shardable) and is most valuable on the bigger
models that already need the 8x slice.

If both can be merged: ship them together. They compose
multiplicatively for HBM and touch nearby code. The combined
expected reduction in per-chip cache HBM:

| Model | L | Today (replicated) | A only | B only | A + B |
|---|---:|---:|---:|---:|---:|
| E4B  |  4 096 | 392 MiB | 147 MiB | 196 MiB | 74 MiB |
| E4B  | 16 384 | 1.51 GiB | 483 MiB | 753 MiB | 241 MiB |
| 31B  |  4 096 | 3.69 GiB | 1.17 GiB | 920 MiB | 290 MiB |
| 31B  | 32 768 | 29.5 GiB | 3.52 GiB | 7.4 GiB | 880 MiB |

(Absolute numbers per chip, batch=1, bf16, 4-chip slice for E4B and
31B. 31B at L=32K with current code does not fit; with both changes,
fits with substantial headroom.)

---

## 4. Risks & Open Questions

1. **`is_full` semantics.** Currently a soft bug today (loop stops
   when layer-0 fills, which today is local-sliding). Change A makes
   this strictly observable. Fix in scope of Change A, but worth
   reviewer eyes.
2. **Mesh discovery for Change B.** Recommend inferring from
   `params` to avoid public-API churn; reviewer may prefer an explicit
   API.
3. **Per-step all-reduce cost on Change B.** Need empirical
   measurement before claiming step-time parity. If the all-reduce
   exceeds ~5% of step time, consider replicating queries after the
   sharded attention output (or using `jax.lax.psum_scatter` /
   `with_sharding_constraint` to keep the reduce out of the critical
   path).
4. **Multi-turn correctness.** Multi-turn reuses
   `prev_turns.cache`. After Change A, the cache shape is
   `{layer_i: [B, layer_cache_size, ...]}` per layer. Code paths that
   inspect cache shape (e.g.
   [`_chat_sampler._remove_eos_token`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_chat_sampler.py#L445)
   touches `cache_info` but only `end_index`) should be audited.
5. **Compatibility with `KVCacheSharingConfig`** for the
   shared-layer path
   ([`gemma4/_config.py:32-84`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py#L32-L84),
   used by E2B and E4B with `frac_shared_layers > 0`). The sharing
   pattern shares cache between layers — Change A's per-layer sizes
   must be consistent across shared layer pairs (which they are, since
   sharing groups layers of the same attention type).
6. **Quantization / LoRA.** Out of scope, but worth noting that the
   cache lives at sampling time (no params-quantization interaction)
   and isn't itself quantized.

---

## 5. Plan of Work

Phased so each phase is independently revertible:

**Phase 0 (this proposal).** Land
[`examples/cache_audit.py`](./examples/cache_audit.py) and
[`examples/cache_probe.py`](./examples/cache_probe.py). They are
read-only diagnostic tools, useful regardless of which fix lands.

**Phase 1 (Change A).** Right-size local-sliding cache.

1. Add per-layer cache sizing in
   [`gemma/gm/nn/gemma4/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma4/_config.py)
   and [`gemma/gm/nn/gemma3n/_config.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/nn/gemma3n/_config.py).
2. Fix `Cache.total_cache_length` and `is_full` in
   [`gemma/gm/utils/_cache_helper.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/utils/_cache_helper.py).
3. Fix prefill cache slice / merge in
   [`gemma/gm/text/_prefill.py`](https://github.com/google-deepmind/gemma/blob/main/gemma/gm/text/_prefill.py)
   to handle per-layer sizes.
4. Add unit tests + numerical-equivalence test.
5. Verify HBM reduction with `examples/cache_probe.py` on E4B at
   L=4096 and L=16384.

Estimated diff: ~80 LOC of source + ~150 LOC of tests.

**Phase 2 (Change B).** Cache sharding contract.

1. Add `cache_partition_spec(mesh)` to `TransformerConfig` (Gemma 4,
   Gemma 1-3, Gemma 3n).
2. Wire mesh inference in `Transformer.init_cache` via the params'
   sharding.
3. Add per-step `with_sharding_constraint` after cache writes in
   each `Attention.__call__`.
4. Add per-step / per-prefill numerical-equivalence + HBM tests.

Estimated diff: ~120 LOC of source + ~200 LOC of tests.

**Phase 3 (optional follow-up).** Address the 2× transient via
prefill donation (§3.3).

---

## 6. Validation / Benchmark Plan

The benchmarks below should be run *before* and *after* each phase to
establish a clean attribution of savings. Use [`examples/cache_probe.py`](./examples/cache_probe.py)
as the primary HBM measurement tool and `time` as decode-rate measurement.

**Hardware:** v5e-4 (4 chips, 16 GB HBM each). v5e-8 if accessible
for 31B confirmation.

**Models:** Gemma4_E2B (sanity, no head-sharding gain), Gemma4_E4B
(primary), Gemma4_31B (extrapolation; v5e-8).

**Workload:** single-turn `chat()` with a fixed prompt and
`max_new_tokens=64`, `multi_turn=False`, `cache_length ∈
{4096, 16384, 32768}`. RNG seeded.

**Metrics per (model, cache_length, change):**

| Metric | Source |
|---|---|
| Per-chip peak HBM during chat() | `device.memory_stats()['peak_bytes_in_use']` |
| Per-chip steady-state HBM after chat() | `device.memory_stats()['bytes_in_use']` |
| End-to-end chat() latency (warm) | `time.time()` around `sampler.chat(...)` |
| Logit hash for first 64 sampled tokens | `hashlib.sha256(jnp.asarray(state.predicted_tokens).tobytes())` |

**Acceptance criteria:**

- HBM: Per-chip peak HBM drops by at least 80% of the predicted
  savings in §3.1 / §3.2 tables. Greedy sampled tokens should match
  before/after the change; logits should stay within BF16 tolerance.
- Latency: ≤ 5% regression on E4B at L=4096. Long-context (L=16384+)
  may improve due to less HBM traffic on the masked region.
- No new compile-time blowups (compile time within 2× of baseline).

---

## 7. Why this is a good idea, briefly

The Gemma-4-specific local-sliding pathology is a structural property
of how `_config.init_cache` is written, not a feature; the masking
code already proves the bytes are unread. The cache replication is
similarly an artifact of "no model knows what mesh the user will run
on" — but the model trivially knows once params have been placed. Both
fixes are local, testable, and unlock long-context evaluation of the
larger Gemma 4 variants on commodity TPU slices. Neither requires
changes to the user-facing API surface.

---

## Appendix A — Diagnostic tooling

This proposal ships two read-only scripts (already in
[`examples/`](./examples/)) used to gather the empirical numbers above.
They are not part of the runtime path.

- **[`examples/cache_audit.py`](./examples/cache_audit.py)** — inspects
  the cache pytree shape/dtype/sharding per leaf without any param
  load. `--shard heads` simulates the proposed Change B sharding so
  reviewers can see what the post-change layout looks like.
- **[`examples/cache_probe.py`](./examples/cache_probe.py)** — runs a
  real `ChatSampler.chat()` with FSDP-sharded params and reports
  per-chip HBM deltas. Used to derive the runtime numbers in §1.1.

Both scripts are useful regression tools to verify Phase 1 and Phase 2
numerically.
