### PR TITLE
Add FORBIDDEN_TOKENS to Gemma4Tokenizer covering image + audio placeholders

### DIFF
--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -483,6 +483,22 @@ class Gemma4Tokenizer(Tokenizer):
 
   special_tokens = _Gemma4SpecialTokens
 
+  # Tokens which are forbidden to be generated in the sampler. Mirrors
+  # `Gemma3Tokenizer` / `Gemma3nTokenizer` but covers both the image and audio
+  # multimodal placeholders, since Gemma 4 uses distinct ids for each
+  # placeholder/start/end token (Gemma 3 reuses `IMAGE_PLACEHOLDER ==
+  # START_OF_IMAGE == 255999`, so listing both there is redundant; in Gemma 4
+  # all six ids are distinct, so all six must be forbidden to keep raw
+  # multimodal placeholders out of text-only generation). See #613.
+  FORBIDDEN_TOKENS = (
+      special_tokens.IMAGE_PLACEHOLDER,
+      special_tokens.START_OF_IMAGE,
+      special_tokens.END_OF_IMAGE,
+      special_tokens.AUDIO_PLACEHOLDER,
+      special_tokens.START_OF_AUDIO,
+      special_tokens.END_OF_AUDIO,
+  )
+
   VERSION = 4
   FORMAT: ClassVar[dialog.Format] = dialog.Format.GEMMA4
 

--- a/gemma/gm/text/_tokenizer_test.py
+++ b/gemma/gm/text/_tokenizer_test.py
@@ -25,3 +25,27 @@ def test_pickle():
   tokenizer.encode('Hello world!')  # Trigger the lazy-loading of the tokenizer.
 
   pickle.dumps(tokenizer)
+
+
+def test_gemma4_tokenizer_forbids_multimodal_placeholder_tokens():
+  """Regression test for https://github.com/google-deepmind/gemma/issues/613.
+
+  Gemma 4 introduced distinct token ids for image and audio multimodal
+  placeholders. The tokenizer must mark all six as forbidden so the sampler
+  cannot generate raw placeholder tokens during text-only inference (which
+  would corrupt the output).
+  """
+  forbidden = gm.text.Gemma4Tokenizer.FORBIDDEN_TOKENS
+  st = gm.text.Gemma4Tokenizer.special_tokens
+  for token in (
+      st.IMAGE_PLACEHOLDER,
+      st.START_OF_IMAGE,
+      st.END_OF_IMAGE,
+      st.AUDIO_PLACEHOLDER,
+      st.START_OF_AUDIO,
+      st.END_OF_AUDIO,
+  ):
+    assert token in forbidden, (
+        f'Token {token!r} ({st(token).name}) must be in Gemma4Tokenizer'
+        f'.FORBIDDEN_TOKENS, but FORBIDDEN_TOKENS is {forbidden!r}'
+    )


### PR DESCRIPTION
## Summary

`Gemma4Tokenizer` did not define `FORBIDDEN_TOKENS`, so it inherited the base class default of `()`. The sampler at `gemma/gm/text/_sampler.py:501` does:

```python
forbidden_tokens = self._normalize_tokens(self.forbidden_tokens)
forbidden_tokens += self.tokenizer.FORBIDDEN_TOKENS
```

For Gemma 4 this added nothing, leaving the sampler free to emit raw multimodal placeholder tokens (`<|image|>`, `<start_of_image>`, `<image|>`, `<|audio|>`, `<start_of_audio>`, `<audio|>`) during text-only inference. The result is corrupted text-only output that includes raw placeholder ids the user never asked for.

## Fix

Mirror the existing `Gemma3Tokenizer` / `Gemma3nTokenizer` pattern on the new class, but include all six distinct multimodal ids. Gemma 3 reuses `IMAGE_PLACEHOLDER == START_OF_IMAGE == 255999`, so listing both there is redundant; in Gemma 4 all six are distinct per `_Gemma4SpecialTokens` (verified directly in this file):

```python
IMAGE_PLACEHOLDER = 258880  # <|image|>
START_OF_IMAGE = 255999     # <|image>
END_OF_IMAGE = 258882       # <image|>
AUDIO_PLACEHOLDER = 258881  # <|audio|>
START_OF_AUDIO = 256000     # <|audio> (BOA)
END_OF_AUDIO = 258883       # <audio|> (EOA)
```

so all six need to be forbidden to keep the sampler from emitting any of them in text-only mode.

## Test Plan

- [x] Added `test_gemma4_tokenizer_forbids_multimodal_placeholder_tokens` in `gemma/gm/text/_tokenizer_test.py`. It iterates over all six expected multimodal ids and asserts each is present in `Gemma4Tokenizer.FORBIDDEN_TOKENS`. This is a class-attribute test, so it does not need to load the actual SentencePiece model.
- [x] Verified via AST that the new `FORBIDDEN_TOKENS` tuple contains exactly the six expected `special_tokens.*` entries.
- [x] No regression for `Gemma3Tokenizer` / `Gemma3nTokenizer` (their `FORBIDDEN_TOKENS` is unchanged).
- [x] No em-dashes / no AI-tells / Google CLA already signed (covered via the mujoco / dm_control umbrella).

Fixes #613.

Credit to @ac12644 for the diagnosis and proposed fix in the issue.
