### PR TITLE
fix(utils): download tokenizer models locally via HTTP to avoid TF GCS C++ segfault on macOS

### DIFF
--- a/gemma/gm/utils/_file_cache.py
+++ b/gemma/gm/utils/_file_cache.py
@@ -28,12 +28,24 @@ def maybe_get_from_cache(
     remote_file_path: epath.PathLike,
     cache_subdir: str,
 ) -> epath.Path:
-  """Returns the cached file if exists, otherwise returns the remote file path."""
-  filename = epath.Path(remote_file_path).name
+  """Returns the cached file if exists, otherwise downloads it and returns local path."""
+  remote_path_str = str(remote_file_path)
+  filename = epath.Path(remote_path_str).name
 
-  cache_filepath = _get_cache_dir() / cache_subdir / filename
+  cache_dir = _get_cache_dir() / cache_subdir
+  cache_filepath = cache_dir / filename
   if cache_filepath.exists():
     return cache_filepath
+    
+  if remote_path_str.startswith('gs://'):
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    http_url = remote_path_str.replace('gs://', 'https://storage.googleapis.com/')
+    print(f"Downloading {filename} to {cache_filepath}...")
+    
+    import urllib.request
+    urllib.request.urlretrieve(http_url, str(cache_filepath))
+    return cache_filepath
+
   return epath.Path(remote_file_path)
 
 


### PR DESCRIPTION
## Description
Fixes #660 
Fixes an issue where `gemma` fails to download/cache `gs://` tokenizer paths efficiently, which triggers the TensorFlow C++ GCS client and results in a `libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed` crash on macOS Apple Silicon at Python interpreter exit.

By explicitly intercepting `gs://` paths and downloading them via standard HTTP (`urllib.request`) directly into the local `~/.gemma/tokenizer/` cache, we completely bypass the C++ GCS client bug.

Additionally, this adds **true local caching** for tokenizer models (previously the code was checking the cache, but never actually saving to it if the file was missing, leading to the full model being fetched over the network on every run).

## Changes
- Modified `gemma/gm/utils/_file_cache.py::maybe_get_from_cache` to translate `gs://` paths to `https://storage.googleapis.com/` and download them natively to the cache directory before returning the local path.
