### PR TITLE
Fix MoERagged docstring return reference

### DIFF
--- a/gemma/gm/nn/gemma4/_moe.py
+++ b/gemma/gm/nn/gemma4/_moe.py
@@ -389,7 +389,7 @@ class MoERagged(nn.Module):
         the router applies only its own router_norm (avoiding a double norm).
 
     Returns:
-      Output of the MoE module.
+      Output of the MoERagged module.
     """
     if unnormalized_x is None:
       unnormalized_x = x


### PR DESCRIPTION
 Fix a copy-paste leftover in `MoERagged.__call__` docstring: the `Returns:` section said "Output of the MoE  
  module" but should say "Output of the MoERagged module"

  Docstring-only; no behavior change.

### Before
    Returns:
      Output of the MoE module.

### After
    Returns:
      Output of the MoERagged module.