### PR TITLE
fix(t5gemma): add missing f-prefix in _normalize_token error message

### DIFF
--- a/gemma/research/t5gemma/sampling.py
+++ b/gemma/research/t5gemma/sampling.py
@@ -511,7 +511,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
+        f'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
         ' single token ids in the vocab.'
     )
   (token_id,) = token_id


### PR DESCRIPTION
## Summary

`_normalize_token()` in `gemma/research/t5gemma/sampling.py` raises a `ValueError` whose message uses `{token!r}` inside a **plain string literal** (no `f` prefix), so users see the placeholder printed literally instead of the offending token:

```
ValueError: Invalid forbidden token: {token!r}. Forbidden tokens must map to single token ids in the vocab.
```

This makes `forbidden_tokens` misconfigurations hard to debug. Adding the `f` prefix interpolates the token as intended:

```
ValueError: Invalid forbidden token: 'hello world'. Forbidden tokens must map to single token ids in the vocab.
```

## Context

This is the same bug class as #658 (`gemma/gm/text/_sampler.py`). A repo-wide sweep for non-f-string error messages containing `{...}` placeholders found exactly two occurrences — the one reported in #658, and this sibling in `research/t5gemma/sampling.py` which that report missed. This PR fixes the t5gemma occurrence.

## Change

One line: add the `f` prefix to the string literal that contains `{token!r}` (the adjacent continuation line has no placeholder and is left unchanged).
