### PR TITLE
Support non-tool use models with Sampler

### DIFF
--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -378,7 +378,8 @@ class Sampler:
         end_tokens=(
             self.tokenizer.special_tokens.EOS,
             self.tokenizer.special_tokens.END_OF_TURN,
-            self.tokenizer.special_tokens.BEGIN_OF_TOOL_RESPONSE,
+            # Some models don't have tool use; for example gemma 2
+            *(getattr(self.tokenizer.special_tokens, "BEGIN_OF_TOOL_RESPONSE", ())),
             *self._normalized_stop_tokens,
         ),
         forbidden_tokens=self._normalized_forbidden_tokens,


### PR DESCRIPTION
`Sampler` unconditionally [accesses](https://github.com/google-deepmind/gemma/blob/05652d59d546d3822b3dfc1f60133cabfe265cbb/gemma/gm/text/_sampler.py#L381) `tokenizer.special_tokens.BEGIN_OF_TOOL_RESPONSE` when this does not always exist ([Gemma2b special tokens](https://github.com/google-deepmind/gemma/blob/05652d59d546d3822b3dfc1f60133cabfe265cbb/gemma/gm/text/_tokenizer.py#L84)).

This PR conditionally adds  the `BEGIN_OF_TOOL_RESPONSE`. Happy to add a test, in which case do you have any guidance on what kind of test you'd like for this? 

