### PR TITLE
fix(security): pin etils-actions/pypi-auto-publish to commit SHA in publish workflow

### DIFF
--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -13,10 +13,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Install deps
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.12"
         # Uncomment to cache of pip dependencies (if tests too slow)
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `pytest_and_autopublish.yml` workflow uses `etils-actions/pypi-auto-publish@v1` — a **mutable tag reference** on a third-party action. If the `v1` tag is silently redirected (compromised maintainer, tag deletion + recreation, repo takeover), malicious code executes in the job that holds `PYPI_API_TOKEN`, enabling a supply-chain attack on every downstream user of this package.

## Fix

Pin to the immutable commit SHA of the current `v1` tag (`@e3c4b4af…`), with the tag preserved as a comment. All other tag-pinned actions (checkout, setup-python) also pinned to SHAs.

Follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).