### PR TITLE
fix: Gemma4Sampler silently drops cache-full condition that Sampler always reported

### DIFF
--- a/gemma/gm/text/_gemma4_sampler.py
+++ b/gemma/gm/text/_gemma4_sampler.py
@@ -260,6 +260,12 @@ class Gemma4Sampler:
     if not has_batch_dim:
       (predicted_texts,) = predicted_texts
 
+    if state.cache_info.is_full.item():
+      kd.utils.status.log(
+          'Cache is full! Try increasing `Gemma4Sampler.cache_length`. Current:'
+          f' {self.cache_length}'
+      )
+
     if return_state:
       return _sampler.SamplerOutput(
           text=predicted_texts,

--- a/gemma/gm/text/_sampler_test.py
+++ b/gemma/gm/text/_sampler_test.py
@@ -14,6 +14,7 @@
 
 from unittest import mock
 from gemma import gm
+from gemma.gm.text import _gemma4_sampler
 from gemma.gm.text import _sampler
 from gemma.gm.text import _sampler_loop
 import jax
@@ -145,3 +146,45 @@ def test_chat_sampler_non_gemma4_dispatch():
     assert isinstance(output, str)
   # Verify sampler.sample was called (not gemma4_sampler.sample).
   mock_sample.assert_called_once()
+
+
+def test_gemma4_sampler_cache_full_warning():
+  """Gemma4Sampler should warn when the KV cache is full after sampling.
+
+  Reproduces the parity gap with Sampler._decode_state(): Sampler has
+  always emitted this warning; Gemma4Sampler was missing it, causing
+  silently truncated responses when cache_length is exceeded.
+  """
+  model = gm.testing.DummyGemma()
+  params = model.init(
+      jax.random.PRNGKey(0),
+      jnp.zeros((5,), dtype=jnp.int32),
+  )
+  params = params['params']
+  tokenizer = gm.testing.DummyTokenizer()
+  sampler = _gemma4_sampler.Gemma4Sampler(
+      model=model,  # pyrefly: ignore[bad-argument-type]
+      params=params,
+      tokenizer=tokenizer,
+      cache_length=128,
+      max_out_length=32,
+  )
+
+  # Build a mock SamplingState where the cache ran full during generation.
+  mock_state = mock.MagicMock()
+  mock_state.predicted_tokens = jnp.zeros((1, 32), dtype=jnp.int32)
+  mock_state.cache_info.is_full.item.return_value = True
+
+  with (
+      mock.patch.object(
+          _sampler_loop.SamplerLoop,
+          'sample',
+          return_value=mock_state,
+      ),
+      mock.patch('kauldron.utils.status.log') as mock_log,
+  ):
+    sampler.sample('hello', last_state=None)
+
+  # The warning must have been emitted exactly once and mention cache_length.
+  mock_log.assert_called_once()
+  assert 'cache_length' in mock_log.call_args[0][0].lower()


### PR DESCRIPTION
### Description

```markdown
## What fixes

When a Gemma 4 prompt + generated output exceeds `cache_length`, the
`SamplerLoop` exits silently via its `~state.cache_info.is_full` stopping
condition. The user gets a truncated (or empty) response with no indication
of why generation stopped.

`Sampler._decode_state()` has always guarded against this with a
`kd.utils.status.log()` call after sampling completes:

```python
# _sampler.py – present since before Gemma 4 was introduced
if state.cache_info.is_full.item():
    kd.utils.status.log(
        'Cache is full! Try increasing `Sampler.cache_length`. ...'
    )
```

`Gemma4Sampler.sample()` performs the identical post-sampling decode
sequence but the guard was never carried over when `Gemma4Sampler` was
introduced. This is a straightforward parity gap.

## Why it matters for Gemma 4 specifically

Gemma 4 multimodal inference expands each `<|image|>` placeholder into
hundreds of soft tokens during preprocessing. This makes hitting
`cache_length` significantly more likely than in text-only scenarios —
and more surprising, since the user's *text* prompt may look well within
budget.

## Change

Added the missing check in `Gemma4Sampler.sample()`, mirroring the
existing pattern in `Sampler`:

```python
if state.cache_info.is_full.item():
    kd.utils.status.log(
        'Cache is full! Try increasing `Gemma4Sampler.cache_length`. Current:'
        f' {self.cache_length}'
    )
```

No logic changes. No API changes. No new dependencies.

## Testing

Added `test_gemma4_sampler_cache_full_warning` to `_sampler_test.py`.
The test mocks `state.cache_info.is_full = True` on the `SamplerLoop`
output and asserts `kd.utils.status.log` is called with a message
containing `cache_length`. This test would have caught the gap before
this fix.

Follows the same mock-based pattern used by the existing dispatch tests
in the file.

