### PR TITLE
Use integer division for GQA reshape group size

### DIFF
--- a/gemma/gm/nn/_modules.py
+++ b/gemma/gm/nn/_modules.py
@@ -241,7 +241,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = query_scaled.shape
       query_scaled = query_scaled.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       logits = jnp.einsum('BTKGH,BSKH->BTKGS', query_scaled, key_proj)
       b, t, k, g, s = logits.shape
@@ -285,7 +285,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = probs.shape
       probs = probs.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       encoded = jnp.einsum('BTKGS,BSKH->BTKGH', probs, value_proj)
       b, t, k, g, h = encoded.shape

--- a/gemma/gm/nn/gemma3n/_modules.py
+++ b/gemma/gm/nn/gemma3n/_modules.py
@@ -339,7 +339,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = query_scaled.shape
       query_scaled = query_scaled.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       logits = jnp.einsum('BTKGH,BSKH->BTKGS', query_scaled, key_proj)
       b, t, k, g, s = logits.shape
@@ -384,7 +384,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = probs.shape
       probs = probs.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       encoded = jnp.einsum('BTKGS,BSKH->BTKGH', probs, value_proj)
       b, t, k, g, h = encoded.shape

--- a/gemma/gm/nn/gemma4/_modules.py
+++ b/gemma/gm/nn/gemma4/_modules.py
@@ -323,7 +323,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = query_proj.shape
       query_proj = query_proj.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       logits = jnp.einsum('BTKGH,BSKH->BTKGS', query_proj, key_proj)
       b, t, k, g, s = logits.shape
@@ -362,7 +362,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = probs.shape
       probs = probs.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       encoded = jnp.einsum('BTKGS,BSKH->BTKGH', probs, value_proj)
       b, t, k, g, h = encoded.shape

--- a/gemma/research/t5gemma/modules.py
+++ b/gemma/research/t5gemma/modules.py
@@ -237,7 +237,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = query_scaled.shape
       query_scaled = query_scaled.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       logits = jnp.einsum('BTKGH,BSKH->BTKGS', query_scaled, key_proj)
       b, t, k, g, s = logits.shape
@@ -269,7 +269,7 @@ class Attention(nn.Module):
       # Reshape matrices to enable einsums over groups.
       b, t, kg, h = probs.shape
       probs = probs.reshape(
-          (b, t, self.num_kv_heads, int(kg / self.num_kv_heads), h)
+          (b, t, self.num_kv_heads, kg // self.num_kv_heads, h)
       )
       encoded = jnp.einsum('BTKGS,BSKH->BTKGH', probs, value_proj)
       b, t, k, g, h = encoded.shape


### PR DESCRIPTION
## Summary

Across the GQA (Grouped Query Attention) reshape operations, the group-size
dimension is computed as `int(kg / self.num_kv_heads)` — float division
followed by truncation via `int()` — instead of integer division
`kg // self.num_kv_heads`.

`kg` (the total number of query heads) is always an exact multiple of
`num_kv_heads` in valid configurations, so this is **behavior-preserving for all
supported models**. Using `//`:

- expresses the integer intent directly (this is a reshape dimension),
- avoids an unnecessary float round-trip, and
- removes the risk of silent shape truncation should the value ever be
  non-divisible.

Fixes #641.

## Changes

Same one-token fix applied to all 8 occurrences across the four attention
modules:

| File | Lines |
|------|-------|
| `gemma/gm/nn/_modules.py` | 244, 288 |
| `gemma/gm/nn/gemma3n/_modules.py` | 342, 387 |
| `gemma/gm/nn/gemma4/_modules.py` | 326, 365 |
| `gemma/research/t5gemma/modules.py` | 240, 272 |

## Testing

The existing GQA coverage exercises this reshape path directly and passes:

```
$ python -m pytest gemma/gm/nn/_modules_test.py -q
15 passed
$ python -m pytest gemma/gm/nn/gemma3n/_modules_test.py -q
24 passed
$ python -m pytest gemma/gm/nn/gemma4/_transformer_test.py -q
4 passed
```

`gemma/gm/nn/_modules_test.py::test_attention_with_gqa` (num_heads=8,
num_kv_heads=4) covers the modified reshape.
