### PR TITLE
Fix missing f-prefix in _normalize_token error message

### DIFF
--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -577,7 +577,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
+        f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
         ' map to single token ids in the vocab.'
     )
   (token_id,) = token_id

--- a/gemma/gm/text/_sampler_test.py
+++ b/gemma/gm/text/_sampler_test.py
@@ -19,6 +19,17 @@ from gemma.gm.text import _sampler_loop
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
+
+
+def test_normalize_token_error_message_includes_token():
+  # A string that does not map to a single token id should raise an error that
+  # names the offending token. Regression test for the message previously being
+  # a plain (non-f) string, which emitted the literal `{token!r}` instead.
+  tokenizer = mock.MagicMock()
+  tokenizer.encode.return_value = [1, 2]  # Not a single token id.
+  with pytest.raises(ValueError, match=r"Invalid token: 'multi_token'"):
+    _sampler._normalize_token(tokenizer, 'multi_token')
 
 
 def test_end_tokens_mask():


### PR DESCRIPTION
## Summary

`_normalize_token()` in `gemma/gm/text/_sampler.py` raises a `ValueError`
when a `stop_token` / `forbidden_token` string does not map to a single
token id. The message string was missing its `f` prefix, so `{token!r}`
was printed **literally** instead of interpolating the offending token,
making these misconfigurations hard to debug.

Fixes #658.

## Change

```diff
-        'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
+        f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
```

The second (implicitly concatenated) line has no placeholders, so it is
left unchanged.

## Testing

Added `test_normalize_token_error_message_includes_token`, which drives the
error path with a fake tokenizer and asserts the message names the token.
Verified it is a real regression guard — it **fails** on the pre-fix code
and **passes** with the fix.

```
$ python -m pytest gemma/gm/text/_sampler_test.py -q
5 passed
```
