### PR TITLE
Fix ChatSampler.conversation crash for non-Gemma4 tokenizers (breaks ToolSampler multi-turn)

### DIFF
--- a/gemma/gm/text/_chat_sampler.py
+++ b/gemma/gm/text/_chat_sampler.py
@@ -430,7 +430,13 @@ class ChatSampler:
   @property
   def conversation(self) -> dialog.Conversation:
     """Returns the conversation."""
-    return dialog.Conversation(''.join(t.text for t in self.turns))
+    text = ''.join(t.text for t in self.turns)
+    if self.tokenizer.FORMAT is not dialog.Format.GEMMA4:
+      # Turns are stored formatted with the tokenizer's legacy format (e.g.
+      # `<start_of_turn>` tags for Gemma 2/3/3n), but `dialog.Conversation`
+      # only parses the canonical `<|turn>` tags.
+      text = self.tokenizer.FORMAT.to_gemma4(text)
+    return dialog.Conversation(text)
 
 
 # Legacy Gemma 3 tokens to detect in user prompts.

--- a/gemma/gm/text/_sampler_test.py
+++ b/gemma/gm/text/_sampler_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+import dialog
 from gemma import gm
 from gemma.gm.text import _sampler
 from gemma.gm.text import _sampler_loop
@@ -145,3 +146,103 @@ def test_chat_sampler_non_gemma4_dispatch():
     assert isinstance(output, str)
   # Verify sampler.sample was called (not gemma4_sampler.sample).
   mock_sample.assert_called_once()
+
+
+def test_chat_sampler_conversation_legacy_format():
+  """Tests that `conversation` parses turns stored in a legacy format.
+
+  Non-Gemma4 tokenizers (Gemma 2/3/3n) store turns formatted with the legacy
+  `<start_of_turn>` tags, while `dialog.Conversation` only parses the canonical
+  `<|turn>` tags. The `conversation` property must convert the stored text to
+  the canonical format before parsing.
+  """
+  model = gm.testing.DummyGemma()
+  params = model.init(
+      jax.random.PRNGKey(0),
+      jnp.zeros((5,), dtype=jnp.int32),
+  )
+  params = params['params']
+  tokenizer = gm.testing.DummyTokenizer()
+  assert tokenizer.FORMAT is not dialog.Format.GEMMA4  # Legacy format.
+  chat_sampler = gm.text.ChatSampler(
+      model=model,  # pyrefly: ignore[bad-argument-type]
+      params=params,
+      tokenizer=tokenizer,
+      cache_length=128,
+      max_out_length=128,
+  )
+
+  mock_sample = mock.MagicMock(
+      return_value=_sampler.SamplerOutput(
+          text='hi there<end_of_turn>',
+          state=mock.MagicMock(),
+      )
+  )
+  with mock.patch.object(
+      type(chat_sampler),
+      'sampler',
+      new_callable=lambda: property(
+          lambda self: mock.MagicMock(sample=mock_sample)
+      ),
+  ):
+    chat_sampler.chat('Hello world')
+
+  conv = chat_sampler.conversation
+  assert len(conv) == 2
+  assert isinstance(conv[0], dialog.User)
+  assert isinstance(conv[1], dialog.Model)
+  assert 'Hello world' in conv[0].as_text()
+  assert 'hi there' in conv[1].as_text()
+
+
+def test_tool_sampler_multi_turn_legacy_format():
+  """Tests `ToolSampler.chat` across turns with a legacy-format tokenizer.
+
+  `ToolSampler.chat` evaluates `self.conversation` on every call (including
+  the internal recursive call after a tool executes), so the property must
+  not fail once turns are stored (regression test).
+  """
+
+  class _NoOpToolHandler(gm.tools.ToolHandlerBase):
+
+    def _tools(self):
+      return []
+
+    def _call_tool(self, name, arguments):
+      return None
+
+  model = gm.testing.DummyGemma()
+  params = model.init(
+      jax.random.PRNGKey(0),
+      jnp.zeros((5,), dtype=jnp.int32),
+  )
+  params = params['params']
+  tokenizer = gm.testing.DummyTokenizer()
+  tool_sampler = gm.text.ToolSampler(
+      model=model,  # pyrefly: ignore[bad-argument-type]
+      params=params,
+      tokenizer=tokenizer,
+      tool_handler=_NoOpToolHandler(),
+      multi_turn=True,
+      cache_length=128,
+      max_out_length=128,
+  )
+
+  mock_sample = mock.MagicMock(
+      return_value=_sampler.SamplerOutput(
+          text='hi there<end_of_turn>',
+          state=mock.MagicMock(),
+      )
+  )
+  with mock.patch.object(
+      type(tool_sampler),
+      'sampler',
+      new_callable=lambda: property(
+          lambda self: mock.MagicMock(sample=mock_sample)
+      ),
+  ):
+    output = tool_sampler.chat('Hello world')
+    assert isinstance(output, str)
+    # Second turn reads `self.conversation` and must not fail.
+    output = tool_sampler.chat('How are you?')
+    assert isinstance(output, str)


### PR DESCRIPTION
## Problem

`ChatSampler.conversation` raises `ValueError` for all non-Gemma4 models after any successful `chat()` turn, and this crashes `ToolSampler` multi-turn and tool-call flows for those model families.

`ChatSampler` stores each turn's text pre-formatted with `self.tokenizer.FORMAT` — which is `dialog.Format.GEMMA3` (`<start_of_turn>...<end_of_turn>` tags) for the Gemma 2/3/3n tokenizers. But the `conversation` property passes the joined text directly to `dialog.Conversation(str)`, which only parses the canonical Gemma4 `<|turn>...<turn|>` tags:

```
ValueError: Conversation root must only contain `turn` tags. Got
'<start_of_turn>user\nHello world<end_of_turn>\n<start_of_turn>model\nhi there<end_of_turn>'
```

The impact goes beyond the public `conversation` property: `ToolSampler.chat` evaluates `self.conversation` on **every** call (`if not self.conversation or not multi_turn`, `_tool_sampler.py:107`), including the internal recursive call made after a tool call executes. So for Gemma 2/3/3n models, turn 1 succeeds but every second turn raises, fully breaking tool use and multi-turn tool chat.

The mismatch was introduced when the turns storage switched to holding text pre-formatted with the tokenizer's legacy format while `conversation` migrated to the `dialog` library's parser, with no format conversion between the two.

## Fix

In the `conversation` property, convert the stored text to the canonical format before parsing:

```python
text = ''.join(t.text for t in self.turns)
if self.tokenizer.FORMAT is not dialog.Format.GEMMA4:
  text = self.tokenizer.FORMAT.to_gemma4(text)
return dialog.Conversation(text)
```

This is a no-op for Gemma4 tokenizers (`FORMAT` is `GEMMA4`) and covers all current `dialog.Format` members.

## Testing

Added two regression tests in `gemma/gm/text/_sampler_test.py`, following the existing mock-based `ChatSampler` test pattern (`gm.testing.DummyGemma` + `DummyTokenizer`, CPU-only, no downloads):

- `test_chat_sampler_conversation_legacy_format` — after a `chat()` turn with a `GEMMA3`-format tokenizer, `conversation` returns a `dialog.Conversation` with the expected `User`/`Model` turns. Fails with the `ValueError` above without the fix.
- `test_tool_sampler_multi_turn_legacy_format` — `ToolSampler.chat` completes a second turn with a legacy-format tokenizer. Fails on turn 2 without the fix.

```
$ pytest gemma/gm/text/ -q
15 passed in 10.99s
```
