### PR TITLE
Fix misleading custom-token id range in tokenizer error message

### DIFF
--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -327,7 +327,7 @@ class Tokenizer:
     for i, token in self.custom_tokens.items():
       if i < 0 or i > 98:
         raise ValueError(
-            f'Custom token id {i} for {token!r} is not in [1, 98].'
+            f'Custom token id {i} for {token!r} is not in [0, 98].'
         )
 
       # Update the piece
@@ -335,7 +335,7 @@ class Tokenizer:
       if piece.piece != f'<unused{i}>':
         raise AssertionError(
             f'Expected custom token id {i} for {token!r} to be `<unused{i}>`,'
-            f' but was {piece.piece}. This indicates the voab file'
+            f' but was {piece.piece}. This indicates the vocab file'
             " isn't as expected."
         )
       piece.piece = token


### PR DESCRIPTION
## What

`Tokenizer._add_custom_tokens` (in `gemma/gm/text/_tokenizer.py`) validates custom-token ids with `if i < 0 or i > 98:`, i.e. it accepts the inclusive range **[0, 98]**. This matches:
- the `custom_tokens` docstring — "mapping the unused id (0-98)"
- the fact that `<unused0>` == `SpecialTokens.CUSTOM + 0`, so `0` is a legal id.

However, the raised `ValueError` told the user the id "is not in **[1, 98]**", wrongly implying `0` is forbidden. A user who correctly passes `{0: '<start_of_audio>'}` succeeds silently, yet the message would mislead anyone debugging.

## Change

- Align the error message bound with the actual check: `[1, 98]` -> `[0, 98]`.
- Fix an adjacent typo in the same method: `voab file` -> `vocab file`.

No logic/behavior change -- message-only.