### PR TITLE
Remove phantom label_smoothing attribute from NpoLoss docstring

### DIFF
--- a/gemma/gm/losses/_npo.py
+++ b/gemma/gm/losses/_npo.py
@@ -30,7 +30,6 @@ class NpoLoss(kd.losses.Loss):
 
   Attributes:
     tau: The temperature of the loss.
-    label_smoothing: The label smoothing to apply to the loss.
     tokens: The key to the tokens to predict.
     sequence_mask: The key to the sequence mask.
     policy_logits: The key to the policy logits.


### PR DESCRIPTION
## What

`NpoLoss` (in `gemma/gm/losses/_npo.py`) documents a `label_smoothing` attribute in its class docstring:

> `label_smoothing: The label smoothing to apply to the loss.`

However, the dataclass has **no** `label_smoothing` field, and the NPO loss it computes — `-jax.nn.log_sigmoid(-po_delta)` — has no label-smoothing term. The line is a copy-paste artifact from the sibling `DpoLoss`, which genuinely declares and uses `label_smoothing` in its loss formula.

A user following the `NpoLoss` docs and passing `NpoLoss(label_smoothing=...)` would hit a `TypeError`, misled into thinking a knob exists that doesn't.

## Change

Remove the stale docstring line so the documented attributes match the actual fields. Docstring-only; no behavior change.