### PR TITLE
Fix wrong parameter name in diffusion attention-mask error message

### DIFF
--- a/gemma/diffusion/_sampler.py
+++ b/gemma/diffusion/_sampler.py
@@ -685,7 +685,7 @@ def _make_global_attention_mask(
 
   if num_valid_tokens is None:
     raise ValueError(
-        'num_valid_samples must be provided if cache_length is set.'
+        'num_valid_tokens must be provided if cache_length is set.'
     )
 
   total_valid = jnp.minimum(num_valid_tokens + canvas_length, cache_length)


### PR DESCRIPTION
## What

In `gemma/diffusion/_sampler.py`, `_make_global_attention_mask` validates its `num_valid_tokens` argument:

```python
if num_valid_tokens is None:
    raise ValueError(
        'num_valid_samples must be provided if cache_length is set.'
    )
```

The message refers to `num_valid_samples`, which is **not** a parameter of the function — the argument is named `num_valid_tokens`. Anyone hitting this error would look for a `num_valid_samples` argument that doesn't exist.

The sibling guard in `_make_block_local_attention_mask` already uses the correct name (`'num_valid_tokens must be provided ...'`).

## Change

Align the error message with the actual parameter name. Message-only; no behavior change.