### PR TITLE
Fix incorrect batch-dim shape annotations on vmapped _get_new_text_tokens_inner

### DIFF
--- a/gemma/gm/vision/_token_utils.py
+++ b/gemma/gm/vision/_token_utils.py
@@ -160,8 +160,8 @@ def _get_new_text_tokens(
 
 
 def _get_new_text_tokens_inner(
-    mm_start: Bool['B L'],  # pyrefly: ignore[not-a-type]
-    text_tokens: Int['B L'],  # pyrefly: ignore[not-a-type]
+    mm_start: Bool['L'],  # pyrefly: ignore[not-a-type, unknown-name]
+    text_tokens: Int['L'],  # pyrefly: ignore[not-a-type, unknown-name]
     offset_by: int,
     length_with_mm: int,
 ) -> Int['L']:  # pyrefly: ignore[not-a-type, unknown-name]


### PR DESCRIPTION
## What

In `gemma/gm/vision/_token_utils.py`, `_get_new_text_tokens_inner` is called **inside** a `vmap`:

```python
return jax.vmap(_get_new_text_tokens_inner, in_axes=(0, 0, None, None))(
    mm_start, text_tokens, offset_by, length_with_mm
)
```

`in_axes=(0, 0, None, None)` strips the leading axis, so the callee operates on single rows of shape `[L]`. But its parameters were annotated as batched:

```python
def _get_new_text_tokens_inner(
    mm_start: Bool['B L'],   # <- wrong, should be ['L']
    text_tokens: Int['B L'], # <- wrong, should be ['L']
    ...
) -> Int['L']:
```

This contradicts three things:
- the function's own docstring — *"`_get_new_text_tokens_positions` without batch dimension"* — and its `-> Int['L']` return type;
- the `vmap` in_axes that remove axis 0;
- the sibling `_get_new_mm_tokens_inner`, which correctly annotates its post-vmap arg as `Bool['L']`.

The body confirms rank-1: it allocates `jnp.zeros((length_with_mm,))` and indexes it 1-D.

## Change

Correct the two annotations to `['L']`, matching the sibling's `# pyrefly: ignore[not-a-type, unknown-name]` style. The function is not `@typechecked`, so this is an annotation/static-analysis fix with no runtime behavior change.