### PR TITLE
Fix end-of-turn token leaking into streamed chat output

### DIFF
--- a/gemma/gm/text/_chat_sampler.py
+++ b/gemma/gm/text/_chat_sampler.py
@@ -468,13 +468,13 @@ def _print_stream(
   text_tokens = []
 
   for state in out:
-    print_(stream, state.text)  # pyrefly: ignore[bad-argument-type]
-
-    text_tokens.append(state.text)
     if (
         state.text == '<end_of_turn>' or state.text == '<turn|>'
     ):  # Last token is not printed.
       continue
+    print_(stream, state.text)  # pyrefly: ignore[bad-argument-type]
+
+    text_tokens.append(state.text)
   out = dataclasses.replace(state, text=''.join(text_tokens))  # pylint: disable=undefined-variable,undefined-loop-variable  # pyrefly: ignore[bad-assignment]
   return out  # pyrefly: ignore[bad-return]
 


### PR DESCRIPTION
## What

`_print_stream` in `gemma/gm/text/_chat_sampler.py` (used by `ChatSampler` on the streaming path) is meant to suppress the end-of-turn marker from the streamed/returned text — the comment says *"Last token is not printed."* But the guard is placed **after** the work it should gate:

```python
for state in out:
    print_(stream, state.text)          # printed before the check
    text_tokens.append(state.text)      # appended before the check
    if state.text == '<end_of_turn>' or state.text == '<turn|>':
        continue                        # no-op: last statement in the loop body
out = dataclasses.replace(state, text=''.join(text_tokens))
```

Because `print_` and `append` run before the `if`, and `continue` is the final statement in the loop body (so it does nothing), the end-of-turn marker (`<end_of_turn>` / `<turn|>`) is:
1. streamed to the user, and
2. concatenated into the returned `SamplerOutput.text`.

Any streamed chat turn ending normally therefore leaks the literal end-of-turn token into the user-visible output.

## Change

Move the guard **ahead** of the print/append so the marker is skipped, matching the documented intent. No other behavior change.

```python
for state in out:
    if state.text == '<end_of_turn>' or state.text == '<turn|>':
        # Last token is not printed.
        continue
    print_(stream, state.text)
    text_tokens.append(state.text)
```