### PR TITLE
Fix typos in _einsum_utils docstring/comment

### DIFF
--- a/gemma/peft/_einsum_utils.py
+++ b/gemma/peft/_einsum_utils.py
@@ -28,7 +28,7 @@ def get_lora_einsum_str_and_shapes(
 ) -> tuple[str, _Shape, _Shape]:
   """Extract the LoRA decomposition from the original einsum parameters.
 
-  This function reqrites a einsum string `inputs,weights->outputs` into
+  This function rewrites an einsum string `inputs,weights->outputs` into
   `inputs,a,b->outputs`.
 
   Args:
@@ -66,7 +66,7 @@ def get_lora_einsum_str_and_shapes(
 
   lora_einsum_str = f'{inputs},{a_str},{b_str}->{outputs}'
 
-  # This assume there's no elipsis in the weights.
+  # This assumes there's no ellipsis in the weights.
   weights_str_to_dim = dict(zip(weights, weights_shape))
   weights_str_to_dim[rank_dim] = rank
   a_shape = tuple(weights_str_to_dim[c] for c in a_str)


### PR DESCRIPTION
Two small typo/grammar fixes in `gemma/peft/_einsum_utils.py` (`get_lora_einsum_str_and_shapes`):

- docstring: `reqrites a einsum` -> `rewrites an einsum`
- comment: `This assume there's no elipsis` -> `This assumes there's no ellipsis`

Comment/docstring only; no behavior change.