### PR TITLE
Fix 'Rational' -> 'Rationale' typo in Cache docstring

### DIFF
--- a/gemma/gm/utils/_cache_helper.py
+++ b/gemma/gm/utils/_cache_helper.py
@@ -32,7 +32,7 @@ _GetItem = _Slice | tuple[_Slice, ...]
 class Cache:
   """Wrapper around the cache to support easy slicing.
 
-  Rational: During prefill, the model expects the cache to be of the same size
+  Rationale: During prefill, the model expects the cache to be of the same size
   as the prompt length. So we slice the cache to match the prompt length.
   During sampling, the full cache is passed and updated in place.
   """


### PR DESCRIPTION
The `Cache` class docstring in `gemma/gm/utils/_cache_helper.py` starts an explanatory note with `Rational:` where `Rationale:` is meant. Docstring only; no behavior change.