### PR TITLE
Fix 'predicated' -> 'predicted' typo in _turn_utils docstring

### DIFF
--- a/gemma/gm/text/_turn_utils.py
+++ b/gemma/gm/text/_turn_utils.py
@@ -35,7 +35,7 @@ class PrevTurns:
 
   @property
   def last_token_pos(self) -> Int['#B']:  # pyrefly: ignore[not-a-type]
-    """Offset of the last predicated token position."""
+    """Offset of the last predicted token position."""
     if self.last_state is None:
       return jnp.zeros((1,), dtype=jnp.int32)
     else:


### PR DESCRIPTION
The `last_token_pos` property docstring in `gemma/gm/text/_turn_utils.py` reads "Offset of the last **predicated** token position" where "**predicted**" is meant (the property tracks the last predicted/generated token). Docstring only; no behavior change.