### PR TITLE
Fix 'a undescore' -> 'an underscore' typo in tokenizer comment

### DIFF
--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -41,7 +41,7 @@ with epy.lazy_imports():
   import plotly.express as px  # pylint: disable=g-import-not-at-top  # pytype: disable=import-error
 
 
-_WHITESPACE_CHAR = '▁'  # Note this is NOT a undescore (▁ != _)
+_WHITESPACE_CHAR = '▁'  # Note this is NOT an underscore (▁ != _)
 
 
 class _DisplayEnumType(enum.EnumType):


### PR DESCRIPTION
The comment on `_WHITESPACE_CHAR` in `gemma/gm/text/_tokenizer.py` reads "Note this is NOT a undescore" — fix the misspelling and article to "an underscore". Comment only; no behavior change.