### PR TITLE
Fix 'argiments' -> 'arguments' typo in _token_utils comment

### DIFF
--- a/gemma/gm/vision/_token_utils.py
+++ b/gemma/gm/vision/_token_utils.py
@@ -221,7 +221,7 @@ def _get_new_mm_tokens(
     offset_by: int,
     length_with_mm: int,
 ) -> Int['B max_num_images num_tokens_per_image+4']:  # pyrefly: ignore[not-a-type]
-  # Jax vmap does not support positional argiments, so need the
+  # Jax vmap does not support positional arguments, so need the
   # _get_new_mm_tokens_inner indirection.
   return jax.vmap(
       _get_new_mm_tokens_inner, in_axes=(0, None, None, None, None)


### PR DESCRIPTION
The comment above `_get_new_mm_tokens` in `gemma/gm/vision/_token_utils.py` reads "Jax vmap does not support positional **argiments**" — fix to "arguments" (the identical comment above `_get_new_text_tokens` is already spelled correctly). Comment only; no behavior change.