### PR TITLE
Fix non-f-string ValueError in t5gemma _normalize_token

### DIFF
--- a/gemma/research/t5gemma/sampling.py
+++ b/gemma/research/t5gemma/sampling.py
@@ -511,7 +511,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
+        f'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
         ' single token ids in the vocab.'
     )
   (token_id,) = token_id


### PR DESCRIPTION
In `gemma/research/t5gemma/sampling.py`, `_normalize_token` raises:

```python
raise ValueError(
    'Invalid forbidden token: {token!r}. Forbidden tokens must map to'
    ' single token ids in the vocab.'
)
```

The first line uses `{token!r}` but is **not** an f-string, so the placeholder is emitted literally — the user sees `Invalid forbidden token: {token!r}` instead of the actual offending token. Add the `f` prefix so the token is interpolated. (The second concatenated line has no placeholders and correctly stays a plain string.)