### PR TITLE
Fix load_params error reporting expected instead of actual checkpoint type

### DIFF
--- a/gemma/gm/ckpts/_checkpoint.py
+++ b/gemma/gm/ckpts/_checkpoint.py
@@ -268,7 +268,7 @@ def load_params(
       raise ValueError(
           'The input params provided to `load_params()` should be the raw'
           " model params matching the Flax `model.init()['params']` structure."
-          f' Got: {_CheckpointType.NESTED}'
+          f' Got: {params.type}'
       )
     if text_only and params.has_mm_params:
       raise ValueError(


### PR DESCRIPTION
In `gemma/gm/ckpts/_checkpoint.py`, `load_params` validates the caller-provided params:

```python
if params.type != _CheckpointType.NESTED:
    raise ValueError(
        'The input params provided to `load_params()` should be the raw'
        " model params matching the Flax `model.init()['params']` structure."
        f' Got: {_CheckpointType.NESTED}'
    )
```

The `Got:` suffix interpolates the constant `_CheckpointType.NESTED` — the **expected** value — so the message always reads `Got: ...NESTED` even though we only reach this branch when `params.type` is something *else*. Report `params.type` (the actual value that failed the check) instead, so the error tells the user what they actually passed.