### PR TITLE
Fix stale method reference in nn comments (_include_vision_embeddings -> _merge_mm_embeddings)

### DIFF
--- a/gemma/gm/nn/_modules.py
+++ b/gemma/gm/nn/_modules.py
@@ -77,7 +77,7 @@ class Embedder(nn.Module):
     # * `mm_soft_embedding_norm` and `mm_input_projection`: Those weights
     #   serve to project the soft tokens from the image encoder into the
     #   embedding space of the text encoder. Those tokens are then merged with
-    #   the text tokens inside `Transformer._include_vision_embeddings`.
+    #   the text tokens inside `Transformer._merge_mm_embeddings`.
     if self.vision_proj_dim:
       self.mm_soft_embedding_norm = _layers.RMSNorm()
       self.mm_input_projection = _layers.Einsum(

--- a/gemma/gm/nn/gemma3n/_modules.py
+++ b/gemma/gm/nn/gemma3n/_modules.py
@@ -91,7 +91,7 @@ class Embedder(nn.Module):
     # * `mm_soft_embedding_norm` and `mm_input_projection`: Those weights
     #   serve to project the soft tokens from the image encoder into the
     #   embedding space of the text encoder. Those tokens are then merged with
-    #   the text tokens inside `Transformer._include_vision_embeddings`.
+    #   the text tokens inside `Transformer._merge_mm_embeddings`.
     if self.vision_proj_dim:
       self.mm_soft_embedding_norm = _layers.RMSNorm()
       self.mm_input_projection = _layers.Einsum(


### PR DESCRIPTION
Comments in `gemma/gm/nn/_modules.py` and `gemma/gm/nn/gemma3n/_modules.py` refer to `Transformer._include_vision_embeddings`, but no such method exists. The actual method is `_merge_mm_embeddings` (`_transformer.py:390`, `gemma3n/_transformer.py:444`); the sibling comment in `gemma4/_modules.py` already uses the correct name. Update the two stale references. Comment only; no behavior change.