### PR TITLE
Fix malformed 'pytlint' lint pragma -> 'pylint' in hd configs

### DIFF
--- a/gemma/diffusion/hackable_diffusion_adapter/configs/sft_pubmedqa.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/configs/sft_pubmedqa.py
@@ -25,7 +25,7 @@ from kauldron import konfig
 # pylint: disable=g-import-not-at-top
 with konfig.imports():
   from gemma.diffusion import _models
-  from gemma.diffusion import _paths  # pytlint: disable=unused-import
+  from gemma.diffusion import _paths  # pylint: disable=unused-import
   from gemma.diffusion.hackable_diffusion_adapter.data.pubmedqa import pubmedqa_data
   from gemma.diffusion.hackable_diffusion_adapter.eval import pubmedqa_eval
   from gemma.diffusion.hackable_diffusion_adapter.hd import gemma_checkpointer

--- a/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku.py
@@ -24,7 +24,7 @@ from kauldron import konfig
 # pylint: disable=g-import-not-at-top
 with konfig.imports():
   from gemma.diffusion import _models
-  from gemma.diffusion import _paths  # pytlint: disable=unused-import
+  from gemma.diffusion import _paths  # pylint: disable=unused-import
   from gemma.diffusion.hackable_diffusion_adapter.data.sudoku import sudoku_data
   from gemma.diffusion.hackable_diffusion_adapter.eval import sudoku_eval
   from gemma.diffusion.hackable_diffusion_adapter.hd import gemma_checkpointer

--- a/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku_full.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku_full.py
@@ -83,7 +83,7 @@ _modules.Block.__call__ = new_call
 # pylint: disable=g-import-not-at-top
 with konfig.imports():
   from gemma.diffusion import _models
-  from gemma.diffusion import _paths  # pytlint: disable=unused-import
+  from gemma.diffusion import _paths  # pylint: disable=unused-import
   from gemma.diffusion.hackable_diffusion_adapter.data.sudoku import sudoku_data
   from gemma.diffusion.hackable_diffusion_adapter.eval import sudoku_eval
   from gemma.diffusion.hackable_diffusion_adapter.hd import gemma_checkpointer


### PR DESCRIPTION
Three hackable-diffusion config files use `# pytlint: disable=unused-import` to silence the intentional `_paths` import. `pytlint` is not a recognized pragma prefix, so the warning is never actually suppressed. Correct it to `pylint` in:

- `hackable_diffusion_adapter/configs/sft_sudoku.py`
- `hackable_diffusion_adapter/configs/sft_pubmedqa.py`
- `hackable_diffusion_adapter/configs/sft_sudoku_full.py`