### PR TITLE
Fix 'Ouptut' -> 'Output' typo in data docstrings

### DIFF
--- a/gemma/gm/data/_functional.py
+++ b/gemma/gm/data/_functional.py
@@ -116,7 +116,7 @@ def make_seq2seq_fields(
   prompt = [10, 11, 12, 13],
   response = [20, 21, 1],  # Here, response ends with EOS token.
 
-  # Ouptut:
+  # Output:
   out.input =       [10, 11, 12, 13, 20, 21],
   out.target =      [11, 12, 13, 20, 21,  1],
   out.target_mask = [ 0,  0,  0,  1,  1,  1],

--- a/gemma/gm/data/_tasks.py
+++ b/gemma/gm/data/_tasks.py
@@ -80,7 +80,7 @@ class Seq2SeqTask(grain.MapTransform):
       'prompt': 'Hello! I would love to visit France.',
       'response': 'Bonjour ! J'adorerais visiter la France.',
   }
-  # Ouptut:
+  # Output:
   {
       'input': i32['max_length'],
       'target': i32['max_length 1'],

--- a/gemma/gm/data/_transforms.py
+++ b/gemma/gm/data/_transforms.py
@@ -133,7 +133,7 @@ class AddSeq2SeqFields(grain.MapTransform):
       'prompt': [10, 11, 12, 13],
       'response': [20, 21, 1],  # Here, response ends with EOS token.
   }
-  # Ouptut:
+  # Output:
   {
       'input':       [10, 11, 12, 13, 20, 21],
       'target':      [11, 12, 13, 20, 21,  1],


### PR DESCRIPTION
The same `# Ouptut:` transposition typo appears in three `gemma/gm/data/` docstring examples (`_transforms.py`, `_tasks.py`, `_functional.py`). Fix to `# Output:`. Docstring only; no behavior change.