### PR TITLE
Fix 'specifiy' -> 'specify' typo in transformer comments

### DIFF
--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -107,7 +107,7 @@ class Transformer(nn.Module):
   attention_mask: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):

--- a/gemma/gm/nn/gemma3n/_transformer.py
+++ b/gemma/gm/nn/gemma3n/_transformer.py
@@ -108,7 +108,7 @@ class Gemma3nTransformer(_transformer.Transformer):
   images: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()  # pyrefly: ignore[bad-override]
 
   def __post_init__(self):

--- a/gemma/gm/nn/gemma4/_transformer.py
+++ b/gemma/gm/nn/gemma4/_transformer.py
@@ -128,7 +128,7 @@ class Transformer(nn.Module):
   images: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):


### PR DESCRIPTION
The same `# Model info to specifiy the tokenizer version and default checkpoint.` comment typo appears in `gemma/gm/nn/_transformer.py`, `gemma4/_transformer.py`, and `gemma3n/_transformer.py`. Fix `specifiy` -> `specify`. Comment only; no behavior change.