### PR TITLE
Fix QueryPreAttentionNormalisation docstring to describe query scaling

### DIFF
--- a/gemma/gm/nn/_config.py
+++ b/gemma/gm/nn/_config.py
@@ -43,7 +43,7 @@ def make_attention_layers_types(
 
 
 class QueryPreAttentionNormalisation(enum.Enum):
-  """Initialization strategy."""
+  """Query pre-attention scaling strategy."""
 
   # Whether to scale the query by 1/sqrt(head_dim)
   BY_ONE_OVER_SQRT_HEAD_DIM = enum.auto()

--- a/gemma/gm/nn/gemma3n/_config.py
+++ b/gemma/gm/nn/gemma3n/_config.py
@@ -84,7 +84,7 @@ def create_kv_cache_sharing_patterns(  # pylint: disable=invalid-name
 
 
 class QueryPreAttentionNormalisation(enum.Enum):
-  """Initialization strategy."""
+  """Query pre-attention scaling strategy."""
 
   # Apply no scaling.
   NONE = enum.auto()


### PR DESCRIPTION
`QueryPreAttentionNormalisation` (in `gemma/gm/nn/_config.py` and `gemma/gm/nn/gemma3n/_config.py`) is documented as `"""Initialization strategy."""`, but every enum member selects how the **query is scaled before attention** (`BY_ONE_OVER_SQRT_HEAD_DIM`, `BY_EMBED_DIM_DIV_NUM_HEADS`, `BY_ONE_OVER_SQRT_EMBED_DIM_DIV_NUM_HEADS`, `NONE`) — nothing to do with initialization. The docstring appears copy-pasted from an unrelated enum. Replace it with `"""Query pre-attention scaling strategy."""`. Docstring only; no behavior change.