### PR TITLE
Fix comment referencing non-existent variable in sft_model

### DIFF
--- a/gemma/diffusion/hackable_diffusion_adapter/hd/sft_model.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/hd/sft_model.py
@@ -404,7 +404,7 @@ class SFTDiffusion(nn.Module):
         jax.random.uniform(self.make_rng('sampling'), shape=(batch_size,))
         < self.self_cond_prob
     )
-    # Reshape to broadcast with x0_hat_logits (Batch, ..., Channels)
+    # Reshape to broadcast with sc_logits (Batch, ..., Channels)
     do_self_cond = do_self_cond.reshape(
         (batch_size,) + (1,) * (sc_logits.ndim - 1)
     )


### PR DESCRIPTION
In `gemma/diffusion/hackable_diffusion_adapter/hd/sft_model.py`, a comment reads `# Reshape to broadcast with x0_hat_logits`, but no `x0_hat_logits` exists in the module. The reshape on the following lines broadcasts `do_self_cond` against `sc_logits` (used in the subsequent `jnp.where(do_self_cond, sc_logits, zero_logits)`). Update the comment to `sc_logits`. Comment only; no behavior change.