### PR TITLE
Fix _maybe_unbatch return annotation (Float -> Array) in t5gemma

### DIFF
--- a/gemma/research/t5gemma/sampling.py
+++ b/gemma/research/t5gemma/sampling.py
@@ -94,7 +94,7 @@ class SamplerOutput:
     """Predicted tokens."""
     return self._maybe_unbatch(self.state.predicted_tokens)
 
-  def _maybe_unbatch(self, x: Array['B *d']) -> Float['*d']:  # pyrefly: ignore[unknown-name]
+  def _maybe_unbatch(self, x: Array['B *d']) -> Array['*d']:  # pyrefly: ignore[unknown-name]
     if isinstance(self.text, str):
       (x,) = x
     return x


### PR DESCRIPTION
In `gemma/research/t5gemma/sampling.py`, `_maybe_unbatch` is annotated:

```python
def _maybe_unbatch(self, x: Array['B *d']) -> Float['*d']:
```

The body just unbatches and returns `x` unchanged (dtype-preserving), and its only caller is the `tokens` property, declared `Int['B L'] | Int['L']` and passing the integer `predicted_tokens` buffer. So the return is never `Float` — it's whatever integer array is passed in. Change the return annotation to mirror the generic input type `Array['*d']`, which is correct for a dtype-preserving passthrough. Annotation only; no behavior change.