### PR TITLE
Fix assorted docstring/comment typos across the codebase

### DIFF
--- a/gemma/gm/data/_functional.py
+++ b/gemma/gm/data/_functional.py
@@ -116,7 +116,7 @@ def make_seq2seq_fields(
   prompt = [10, 11, 12, 13],
   response = [20, 21, 1],  # Here, response ends with EOS token.
 
-  # Ouptut:
+  # Output:
   out.input =       [10, 11, 12, 13, 20, 21],
   out.target =      [11, 12, 13, 20, 21,  1],
   out.target_mask = [ 0,  0,  0,  1,  1,  1],

--- a/gemma/gm/data/_tasks.py
+++ b/gemma/gm/data/_tasks.py
@@ -80,7 +80,7 @@ class Seq2SeqTask(grain.MapTransform):
       'prompt': 'Hello! I would love to visit France.',
       'response': 'Bonjour ! J'adorerais visiter la France.',
   }
-  # Ouptut:
+  # Output:
   {
       'input': i32['max_length'],
       'target': i32['max_length 1'],

--- a/gemma/gm/data/_transforms.py
+++ b/gemma/gm/data/_transforms.py
@@ -133,7 +133,7 @@ class AddSeq2SeqFields(grain.MapTransform):
       'prompt': [10, 11, 12, 13],
       'response': [20, 21, 1],  # Here, response ends with EOS token.
   }
-  # Ouptut:
+  # Output:
   {
       'input':       [10, 11, 12, 13, 20, 21],
       'target':      [11, 12, 13, 20, 21,  1],

--- a/gemma/gm/nn/_transformer.py
+++ b/gemma/gm/nn/_transformer.py
@@ -107,7 +107,7 @@ class Transformer(nn.Module):
   attention_mask: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):

--- a/gemma/gm/nn/gemma3n/_transformer.py
+++ b/gemma/gm/nn/gemma3n/_transformer.py
@@ -108,7 +108,7 @@ class Gemma3nTransformer(_transformer.Transformer):
   images: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()  # pyrefly: ignore[bad-override]
 
   def __post_init__(self):

--- a/gemma/gm/nn/gemma4/_transformer.py
+++ b/gemma/gm/nn/gemma4/_transformer.py
@@ -128,7 +128,7 @@ class Transformer(nn.Module):
   images: kontext.Key | None = None
 
   config: _config.TransformerConfig
-  # Model info to specifiy the tokenizer version and default checkpoint.
+  # Model info to specify the tokenizer version and default checkpoint.
   INFO: ClassVar[ModelInfo] = ModelInfo()
 
   def __post_init__(self):

--- a/gemma/gm/text/_tokenizer.py
+++ b/gemma/gm/text/_tokenizer.py
@@ -41,7 +41,7 @@ with epy.lazy_imports():
   import plotly.express as px  # pylint: disable=g-import-not-at-top  # pytype: disable=import-error
 
 
-_WHITESPACE_CHAR = '▁'  # Note this is NOT a undescore (▁ != _)
+_WHITESPACE_CHAR = '▁'  # Note this is NOT an underscore (▁ != _)
 
 
 class _DisplayEnumType(enum.EnumType):

--- a/gemma/gm/text/_turn_utils.py
+++ b/gemma/gm/text/_turn_utils.py
@@ -35,7 +35,7 @@ class PrevTurns:
 
   @property
   def last_token_pos(self) -> Int['#B']:  # pyrefly: ignore[not-a-type]
-    """Offset of the last predicated token position."""
+    """Offset of the last predicted token position."""
     if self.last_state is None:
       return jnp.zeros((1,), dtype=jnp.int32)
     else:

--- a/gemma/gm/utils/_cache_helper.py
+++ b/gemma/gm/utils/_cache_helper.py
@@ -32,7 +32,7 @@ _GetItem = _Slice | tuple[_Slice, ...]
 class Cache:
   """Wrapper around the cache to support easy slicing.
 
-  Rational: During prefill, the model expects the cache to be of the same size
+  Rationale: During prefill, the model expects the cache to be of the same size
   as the prompt length. So we slice the cache to match the prompt length.
   During sampling, the full cache is passed and updated in place.
   """

--- a/gemma/gm/vision/_token_utils.py
+++ b/gemma/gm/vision/_token_utils.py
@@ -221,7 +221,7 @@ def _get_new_mm_tokens(
     offset_by: int,
     length_with_mm: int,
 ) -> Int['B max_num_images num_tokens_per_image+4']:  # pyrefly: ignore[not-a-type]
-  # Jax vmap does not support positional argiments, so need the
+  # Jax vmap does not support positional arguments, so need the
   # _get_new_mm_tokens_inner indirection.
   return jax.vmap(
       _get_new_mm_tokens_inner, in_axes=(0, None, None, None, None)

--- a/gemma/peft/_einsum_utils.py
+++ b/gemma/peft/_einsum_utils.py
@@ -28,7 +28,7 @@ def get_lora_einsum_str_and_shapes(
 ) -> tuple[str, _Shape, _Shape]:
   """Extract the LoRA decomposition from the original einsum parameters.
 
-  This function reqrites a einsum string `inputs,weights->outputs` into
+  This function rewrites an einsum string `inputs,weights->outputs` into
   `inputs,a,b->outputs`.
 
   Args:
@@ -66,7 +66,7 @@ def get_lora_einsum_str_and_shapes(
 
   lora_einsum_str = f'{inputs},{a_str},{b_str}->{outputs}'
 
-  # This assume there's no elipsis in the weights.
+  # This assumes there's no ellipsis in the weights.
   weights_str_to_dim = dict(zip(weights, weights_shape))
   weights_str_to_dim[rank_dim] = rank
   a_shape = tuple(weights_str_to_dim[c] for c in a_str)

--- a/gemma/peft/_quantization_utils.py
+++ b/gemma/peft/_quantization_utils.py
@@ -71,15 +71,15 @@ def quantize(
 ) -> PyTree:
   """Quantizes the given params.
 
-  In ths API, we convert the elements of params in order to actually get
-  quantized values. It is currently limited to INT$ per-channel weight
+  In this API, we convert the elements of params in order to actually get
+  quantized values. It is currently limited to INT4/INT8 per-channel weight
   quantization.
 
   Args:
     params: The params to quantize.
     method: The quantization method to use.
     checkpoint_kernel_key: The key of the kernel in the checkpoint (in
-      pre-trained checkpoitns that is 'w').
+      pre-trained checkpoints that is 'w').
     in_place_keys: Whether to quantize the keys in place.
 
   Returns:
@@ -146,7 +146,7 @@ def quantize(
       data = quantize_leaf(data, checkpoint_kernel_key)
     # This hack is required because the FeedForward layer call two different
     # Einsum with using `nn.share_scope`, so the two wrappers need a different
-    # name. Weights are not stored under any kernel key and are isntead under
+    # name. Weights are not stored under any kernel key and are instead under
     # the following names.
     if 'gating_einsum' in data or 'linear' in data:
       data = quantize_leaf(data, 'gating_einsum')


### PR DESCRIPTION
Consolidates several small spelling/typo fixes into a single PR (docstrings and comments only — no code or behavior change).

| File(s) | Fix |
|---|---|
| `peft/_einsum_utils.py` | `reqrites a einsum` → `rewrites an einsum`; `This assume there's no elipsis` → `This assumes there's no ellipsis` |
| `gm/utils/_cache_helper.py` | `Rational:` → `Rationale:` |
| `gm/text/_turn_utils.py` | `predicated` → `predicted` |
| `gm/text/_tokenizer.py` | `a undescore` → `an underscore` |
| `gm/vision/_token_utils.py` | `argiments` → `arguments` |
| `peft/_quantization_utils.py` | `ths` → `this`; `INT$` → `INT4/INT8`; `checkpoitns` → `checkpoints`; `isntead` → `instead` |
| `gm/data/{_transforms,_tasks,_functional}.py` | `Ouptut` → `Output` |
| `gm/nn/{_transformer, gemma4/_transformer, gemma3n/_transformer}.py` | `specifiy` → `specify` |

Note for maintainers: this supersedes the individually-filed typo PRs #748, #749, #750, #751, #752, #757, #758, #759, which I'm closing in favor of this single bundle.
