### PR TITLE
Implement peft.fuse_params / unfuse_params for LoRA weight fusion

### DIFF
--- a/gemma/peft/README.md
+++ b/gemma/peft/README.md
@@ -176,7 +176,18 @@ assert lora == {
 }
 ```
 
-To fuse the LoRA params:
+To fuse the LoRA params into the base weights (for LoRA-free inference):
+
+```python
+# Fold `a @ b` into `kernel` / `w` (adapters are kept for reversibility).
+fused_params = peft.fuse_params(params)
+
+# Optional: drop the adapter branch and load into a non-LoRA model.
+fused_params, _ = peft.split_params(fused_params)
+
+# Reverse a previous fuse while adapters are still present:
+params = peft.unfuse_params(peft.fuse_params(params))
+```
 
 *   `peft.fuse_params`: Fuse the LoRA params into the original params weights.
-*   `peft.unfuse_params`: Reverse of `fuse_params`, recover the LoRA params.
+*   `peft.unfuse_params`: Reverse of `fuse_params`, subtract the LoRA delta.

--- a/gemma/peft/_tree_utils.py
+++ b/gemma/peft/_tree_utils.py
@@ -16,9 +16,14 @@
 
 from __future__ import annotations
 
+import itertools
 from typing import Any, NamedTuple
 
+import jax
+import jax.numpy as jnp
+
 _ParamsDict = dict[str, Any]
+_WEIGHT_KEYS = ('kernel', 'w')
 
 
 class SplittedParams(NamedTuple):
@@ -137,9 +142,122 @@ def merge_params(original: _ParamsDict, lora: _ParamsDict) -> _ParamsDict:
   return _merge_recursive(original, lora)
 
 
-def fuse_params():
-  raise NotImplementedError()
+def fuse_params(params: _ParamsDict) -> _ParamsDict:
+  """Fuse LoRA adapters into the base weight tensors.
+
+  For every subtree that contains both a base weight (`kernel` or `w`) and a
+  `lora` branch with `a` / `b`, this replaces the weight with
+  `weight + lora_delta(a, b)`.
+
+  The `lora` adapters are left in the tree so `unfuse_params` can reverse the
+  operation. After fusing, callers that want LoRA-free inference can drop the
+  adapters with `split_params` and load the fused weights into a non-LoRA model.
+
+  This mirrors the usual LoRA merge semantics:
+
+  * Dense: `kernel += a @ b`
+  * Einsum / DenseGeneral (no batch dims): contract `a` and `b` over the rank
+    axis, then permute if needed so the result matches the weight layout.
+
+  LoRA DenseGeneral layers with non-empty `batch_dims` are not supported
+  because those adapters are not shared with a single base kernel.
+
+  Args:
+    params: Nested parameter tree, typically containing LoRA adapters.
+
+  Returns:
+    A new parameter tree with LoRA deltas folded into the base weights.
+  """
+  return _map_lora_fusion(params, sign=1)
 
 
-def unfuse_params():
-  raise NotImplementedError()
+def unfuse_params(params: _ParamsDict) -> _ParamsDict:
+  """Inverse of `fuse_params`.
+
+  Subtracts the LoRA delta from each fused base weight. Requires the `lora`
+  adapters (`a`, `b`) to still be present in the tree (as left by
+  `fuse_params`).
+
+  Args:
+    params: Nested parameter tree previously returned by `fuse_params`.
+
+  Returns:
+    A new parameter tree with LoRA deltas removed from the base weights.
+  """
+  return _map_lora_fusion(params, sign=-1)
+
+
+def _map_lora_fusion(params: _ParamsDict, *, sign: int) -> _ParamsDict:
+  """Recursively apply `weight += sign * lora_delta` for every LoRA node."""
+
+  def _recurse(node: Any) -> Any:
+    if not isinstance(node, dict):
+      return node
+
+    new_node = {key: _recurse(value) for key, value in node.items()}
+    lora = new_node.get('lora')
+    if not isinstance(lora, dict) or 'a' not in lora or 'b' not in lora:
+      return new_node
+
+    weight_key = _find_weight_key(new_node)
+    if weight_key is None:
+      return new_node
+
+    delta = _lora_weight_delta(lora['a'], lora['b'], new_node[weight_key])
+    new_node[weight_key] = new_node[weight_key] + sign * delta
+    return new_node
+
+  return _recurse(params)
+
+
+def _find_weight_key(node: _ParamsDict) -> str | None:
+  for key in _WEIGHT_KEYS:
+    value = node.get(key)
+    if _is_array(value):
+      return key
+  return None
+
+
+def _is_array(value: Any) -> bool:
+  return isinstance(value, (jax.Array, jnp.ndarray)) or (
+      hasattr(value, 'shape')
+      and hasattr(value, 'dtype')
+      and hasattr(value, '__array__')
+  )
+
+
+def _lora_weight_delta(a: Any, b: Any, weight: Any) -> jax.Array:
+  """Materialize the LoRA update with the same shape as `weight`."""
+  a = jnp.asarray(a)
+  b = jnp.asarray(b)
+  weight = jnp.asarray(weight)
+
+  if a.shape[-1] != b.shape[0]:
+    raise ValueError(
+        'Unsupported LoRA layout for fusion: expected `b` to start with the '
+        f'rank dimension matching `a.shape[-1]` (got a.shape={a.shape}, '
+        f'b.shape={b.shape}). LoRA DenseGeneral with non-empty batch_dims is '
+        'not supported by fuse_params/unfuse_params.'
+    )
+
+  delta = jnp.tensordot(a, b, axes=([-1], [0]))
+  if delta.shape == weight.shape:
+    return delta
+
+  if sorted(delta.shape) != sorted(weight.shape):
+    raise ValueError(
+        'LoRA delta shape is incompatible with the base weight: '
+        f'delta.shape={delta.shape}, weight.shape={weight.shape}, '
+        f'a.shape={a.shape}, b.shape={b.shape}.'
+    )
+
+  # Einsum LoRA factors are built as (reduced_dims + rank) / (rank + out_dims)
+  # in weight-letter order, which can differ from the original weight layout.
+  for perm in itertools.permutations(range(delta.ndim)):
+    if tuple(delta.shape[i] for i in perm) == weight.shape:
+      return jnp.transpose(delta, perm)
+
+  raise ValueError(
+      'Could not permute LoRA delta to match the base weight layout: '
+      f'delta.shape={delta.shape}, weight.shape={weight.shape}.'
+  )

--- a/gemma/peft/_tree_utils_test.py
+++ b/gemma/peft/_tree_utils_test.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
+from flax import linen as nn
 from gemma import peft
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
 
 
 def test_split_params():
@@ -62,3 +69,167 @@ def test_split_params():
   }
 
   assert peft.merge_params(original, lora) == params
+
+
+def _dense_to_lora(module):
+  if isinstance(module, nn.Dense):
+    return peft.LoRADense(rank=2, wrapped=module)
+  if isinstance(module, nn.Einsum):
+    return peft.LoRAEinsum(rank=2, wrapped=module)
+  if isinstance(module, nn.DenseGeneral):
+    return peft.LoRADenseGeneral(rank=2, wrapped=module)
+  return module
+
+
+class _FusionModule(nn.Module):
+
+  @nn.compact
+  def __call__(self, x):
+    y_dense = nn.Dense(3, use_bias=True)(x)
+    y_einsum = nn.Einsum(
+        shape=(4, 2, 3),
+        einsum_str='bi,ijk->bjk',
+    )(x)
+    y_general = nn.DenseGeneral(features=(2, 3), axis=-1)(x)
+    return {
+        'dense': y_dense,
+        'einsum': y_einsum,
+        'general': y_general,
+    }
+
+
+def _with_nonzero_lora_b(params, layer_name, key):
+  params = copy.deepcopy(params)
+  layer = params['params'][layer_name]
+  layer['lora']['b'] = jax.random.normal(key, layer['lora']['b'].shape)
+  return params
+
+
+def test_fuse_params_matches_lora_forward():
+  model = _FusionModule()
+  x = jax.random.normal(jax.random.key(0), (2, 4))
+
+  with peft.ModuleInterceptor(_dense_to_lora):
+    _, params = model.init_with_output(jax.random.key(1), x)
+
+  # Make LoRA non-trivial (b is zero-initialized by default).
+  params = _with_nonzero_lora_b(params, 'Dense_0', jax.random.key(2))
+  params = _with_nonzero_lora_b(params, 'Einsum_0', jax.random.key(3))
+  params = _with_nonzero_lora_b(params, 'DenseGeneral_0', jax.random.key(4))
+
+  with peft.ModuleInterceptor(_dense_to_lora):
+    lora_out = model.apply(params, x)
+
+  fused = peft.fuse_params(params)
+  # Base model (no LoRA wrappers) with fused weights should match LoRA forward.
+  fused_base, _ = peft.split_params(fused)
+  fused_out = model.apply(fused_base, x)
+
+  def assert_close(actual, expected):
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
+  assert_close(fused_out['dense'], lora_out['dense'])
+  assert_close(fused_out['einsum'], lora_out['einsum'])
+  assert_close(fused_out['general'], lora_out['general'])
+
+  # Adapters remain present so unfuse can reverse the merge.
+  assert 'lora' in fused['params']['Dense_0']
+  assert fused['params']['Dense_0']['lora']['a'].shape == (4, 2)
+  assert fused['params']['Dense_0']['lora']['b'].shape == (2, 3)
+
+
+def test_fuse_unfuse_roundtrip():
+  model = _FusionModule()
+  x = jnp.ones((1, 4))
+  with peft.ModuleInterceptor(_dense_to_lora):
+    params = model.init(jax.random.key(0), x)
+
+  params = _with_nonzero_lora_b(params, 'Dense_0', jax.random.key(5))
+  params = _with_nonzero_lora_b(params, 'Einsum_0', jax.random.key(6))
+  params = _with_nonzero_lora_b(params, 'DenseGeneral_0', jax.random.key(7))
+
+  fused = peft.fuse_params(params)
+  restored = peft.unfuse_params(fused)
+
+  np.testing.assert_allclose(
+      restored['params']['Dense_0']['kernel'],
+      params['params']['Dense_0']['kernel'],
+      rtol=1e-5,
+      atol=1e-5,
+  )
+  np.testing.assert_allclose(
+      restored['params']['Einsum_0']['kernel'],
+      params['params']['Einsum_0']['kernel'],
+      rtol=1e-5,
+      atol=1e-5,
+  )
+  np.testing.assert_allclose(
+      restored['params']['DenseGeneral_0']['kernel'],
+      params['params']['DenseGeneral_0']['kernel'],
+      rtol=1e-5,
+      atol=1e-5,
+  )
+
+
+def test_fuse_params_noop_without_lora():
+  params = {
+      'dense': {
+          'kernel': jnp.arange(6.0).reshape(3, 2),
+          'bias': jnp.zeros((2,)),
+      }
+  }
+  fused = peft.fuse_params(params)
+  np.testing.assert_array_equal(
+      fused['dense']['kernel'], params['dense']['kernel']
+  )
+
+
+def test_fuse_params_dense_manual():
+  a = jnp.arange(8.0).reshape(4, 2)
+  b = jnp.arange(6.0).reshape(2, 3)
+  kernel = jnp.ones((4, 3))
+  params = {
+      'layer': {
+          'kernel': kernel,
+          'lora': {'a': a, 'b': b},
+      }
+  }
+  fused = peft.fuse_params(params)
+  np.testing.assert_allclose(fused['layer']['kernel'], kernel + a @ b)
+
+  # Deployment path: drop adapters after fusion.
+  original, _ = peft.split_params(fused)
+  assert 'lora' not in original['layer']
+  np.testing.assert_allclose(original['layer']['kernel'], kernel + a @ b)
+
+
+def test_fuse_params_einsum_weight_named_w():
+  # Mimic Gemma's custom Einsum param name (`w`) with a layout that needs a
+  # transpose after contracting the LoRA factors (SNDH vs D+SNH order).
+  a = jax.random.normal(jax.random.key(2), (8, 2))  # D, r
+  b = jax.random.normal(jax.random.key(3), (2, 3, 4, 5))  # r, S, N, H
+  delta_dsnh = jnp.tensordot(a, b, axes=([-1], [0]))  # D, S, N, H
+  weight = jnp.transpose(delta_dsnh, (1, 2, 0, 3))  # S, N, D, H
+  params = {
+      'qkv': {
+          'w': jnp.zeros_like(weight),
+          'lora': {'a': a, 'b': b},
+      }
+  }
+  fused = peft.fuse_params(params)
+  np.testing.assert_allclose(fused['qkv']['w'], weight, rtol=1e-5, atol=1e-5)
+
+
+def test_fuse_params_rejects_unsupported_layout():
+  params = {
+      'layer': {
+          'kernel': jnp.ones((4, 3)),
+          'lora': {
+              # Rank is not leading in b (simulates batched DenseGeneral).
+              'a': jnp.ones((2, 4, 2)),
+              'b': jnp.ones((2, 2, 3)),
+          },
+      }
+  }
+  with pytest.raises(ValueError, match='LoRA delta shape is incompatible'):
+    peft.fuse_params(params)


### PR DESCRIPTION
## Summary
- Implements the documented but stubbed `peft.fuse_params` / `peft.unfuse_params` APIs so LoRA adapters can be folded into base `kernel` / `w` weights for LoRA-free inference.
- Supports Dense (`kernel += a @ b`), Einsum, and DenseGeneral layouts (including Gemma `w` weight names and rank-contract + permute when needed).
- Keeps adapters in the tree so `unfuse_params` can reverse the merge; `split_params` can then drop them for deployment.
- Adds unit tests for forward equivalence vs live LoRA, round-trip fuse/unfuse, `w`-named einsum fusion, no-op trees, and unsupported layouts.
- Updates `peft/README.md` with a concrete usage example.

## Test plan
- [x] `python -m pytest gemma/peft/_tree_utils_test.py -v` (7 passed)
- [x] Reviewers: run the same tests in CI