### PR TITLE
fix(text): interpolate token value in _normalize_token error message

### DIFF
--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -577,7 +577,7 @@ def _normalize_token(tokenizer, token: str | int) -> int:
   token_id = tokenizer.encode(token)
   if len(token_id) != 1:
     raise ValueError(
-        'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
+        f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
         ' map to single token ids in the vocab.'
     )
   (token_id,) = token_id


### PR DESCRIPTION
Fix for #658: the error message in `_normalize_token()` used a plain string literal with `{token!r}`, so the placeholder was printed literally instead of the offending token value.

```python
# before
raise ValueError(
    'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
    ' map to single token ids in the vocab.'
)
# after
raise ValueError(
    f'Invalid token: {token!r}. `stop_token`s and `forbidden_token`s must'
    ' map to single token ids in the vocab.'
)
```

Now the exception reports the actual token (e.g. `'hello world'`) instead of the raw placeholder, making `stop_tokens` / `forbidden_tokens` misconfigurations debuggable.

Fixes #658
