### PR TITLE
Fix exact-zero DiffusionGemma self-conditioning

### DIFF
--- a/gemma/diffusion/hackable_diffusion_adapter/hd/hd_gemma_network.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/hd/hd_gemma_network.py
@@ -107,6 +107,56 @@ def prefill_kv_cache_with_encoder(
   return kv_cache, encoder_logits, positions, attention_mask
 
 
+def _encode_self_conditioning(
+    embedder: Any,
+    *,
+    sc_logits: jnp.ndarray | None,
+    sc_mask: jnp.ndarray | None,
+    batch_size: int,
+    canvas_length: int,
+    vocab_size: int,
+    dtype: Any,
+) -> jnp.ndarray:
+  """Encodes self-conditioning while preserving an exact-zero sentinel.
+
+  Zero vocabulary logits do not represent zero self-conditioning because
+  ``encode_logits`` applies a softmax before projecting through the embedding
+  table. SFT currently uses all-zero logits as the disabled sentinel, so mask
+  the encoded signal itself for those examples. An explicit mask can also be
+  supplied by callers that already track self-conditioning enablement.
+
+  Args:
+    embedder: Gemma token embedder exposing ``encode_logits``.
+    sc_logits: Optional self-conditioning logits of shape ``[B, L, V]``.
+    sc_mask: Optional per-example or broadcastable boolean enable mask.
+    batch_size: Batch size.
+    canvas_length: Number of denoised tokens.
+    vocab_size: Vocabulary size.
+    dtype: Logit dtype used when an absent signal needs a placeholder tensor.
+
+  Returns:
+    Self-conditioning embeddings with disabled examples set exactly to zero.
+  """
+  if sc_logits is None:
+    sc_logits = jnp.zeros(
+        (batch_size, canvas_length, vocab_size), dtype=dtype
+    )
+    # Keep the encode call below for parameter-initialization behaviour, but
+    # explicitly mark the missing signal as disabled after encoding.
+    sc_mask = jnp.zeros((batch_size,), dtype=jnp.bool_)
+  elif sc_mask is None:
+    # SFT masks disabled examples by replacing their entire logit tensor with
+    # zeros. Preserve that sentinel across the logit-to-embedding boundary.
+    reduce_axes = tuple(range(1, sc_logits.ndim))
+    sc_mask = jnp.any(sc_logits != 0, axis=reduce_axes)
+
+  sc_embeddings = embedder.encode_logits(sc_logits)
+  sc_mask = jnp.asarray(sc_mask, dtype=jnp.bool_)
+  while sc_mask.ndim < sc_embeddings.ndim:
+    sc_mask = sc_mask[..., None]
+  return jnp.where(sc_mask, sc_embeddings, jnp.zeros_like(sc_embeddings))
+
+
 ################################################################################
 # WrappedDiffusionGemmaNetwork Wrapper
 ################################################################################
@@ -197,8 +247,8 @@ class WrappedDiffusionGemmaNetwork(nn.Module):
     Args:
       time: Diffusion time steps.
       xt: Noisy canvas tokens or array.
-      conditioning: Dictionary containing cache, positions, attention_mask, and
-        sc_logits.
+      conditioning: Dictionary containing cache, positions, attention_mask,
+        sc_logits, and an optional self-conditioning enable mask.
       is_training: Whether operating in training mode.
 
     Returns:
@@ -222,17 +272,21 @@ class WrappedDiffusionGemmaNetwork(nn.Module):
     # The HD pipeline passes the self-conditioning signal as raw logits
     # (shape [B, L, V]) under the key 'sc_logits' in the conditioning dict.
     sc_logits = conditioning.get('sc_logits', None)
-    if sc_logits is None:
-      sc_logits = jnp.zeros(
-          (batch_size, canvas_length, vocab_size), dtype=dtype
-      )
+    sc_mask = conditioning.get('sc_mask', None)
 
     positions = conditioning.get('positions', None)
     kv_cache = conditioning.get('kv_cache', None)
     attention_mask = conditioning.get('attention_mask', None)
 
-    # We keep this call to maintain the param init behavior.
-    sc_embeddings = self.gemma_model.embedder.encode_logits(sc_logits)
+    sc_embeddings = _encode_self_conditioning(
+        self.gemma_model.embedder,
+        sc_logits=sc_logits,
+        sc_mask=sc_mask,
+        batch_size=batch_size,
+        canvas_length=canvas_length,
+        vocab_size=vocab_size,
+        dtype=dtype,
+    )
 
     transformer_output = self.gemma_model.call_with_self_conditioning(
         tokens=tokens,

--- a/gemma/diffusion/hackable_diffusion_adapter/hd/hd_gemma_network_test.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/hd/hd_gemma_network_test.py
@@ -1,0 +1,90 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Hackable Diffusion Gemma network wrapper."""
+
+from absl.testing import absltest
+from gemma.diffusion.hackable_diffusion_adapter.hd import hd_gemma_network
+import jax.numpy as jnp
+import numpy as np
+
+
+class _NonZeroZeroLogitEmbedder:
+  """Embedder whose zero logits deliberately map to a nonzero vector."""
+
+  def encode_logits(self, logits):
+    return jnp.ones(logits.shape[:-1] + (3,), dtype=jnp.float32)
+
+
+class SelfConditioningEncodingTest(absltest.TestCase):
+
+  def test_missing_self_conditioning_is_exact_zero_after_encoding(self):
+    embedder = _NonZeroZeroLogitEmbedder()
+
+    raw_zero_encoding = embedder.encode_logits(jnp.zeros((2, 4, 5)))
+    self.assertTrue(bool(jnp.all(raw_zero_encoding != 0)))
+
+    result = hd_gemma_network._encode_self_conditioning(
+        embedder,
+        sc_logits=None,
+        sc_mask=None,
+        batch_size=2,
+        canvas_length=4,
+        vocab_size=5,
+        dtype=jnp.float32,
+    )
+
+    np.testing.assert_array_equal(result, jnp.zeros_like(result))
+
+  def test_zero_logit_sentinel_disables_only_matching_examples(self):
+    embedder = _NonZeroZeroLogitEmbedder()
+    sc_logits = jnp.stack([
+        jnp.ones((4, 5), dtype=jnp.float32),
+        jnp.zeros((4, 5), dtype=jnp.float32),
+    ])
+
+    result = hd_gemma_network._encode_self_conditioning(
+        embedder,
+        sc_logits=sc_logits,
+        sc_mask=None,
+        batch_size=2,
+        canvas_length=4,
+        vocab_size=5,
+        dtype=jnp.float32,
+    )
+
+    np.testing.assert_array_equal(result[0], jnp.ones_like(result[0]))
+    np.testing.assert_array_equal(result[1], jnp.zeros_like(result[1]))
+
+  def test_explicit_mask_overrides_zero_logit_sentinel_inference(self):
+    embedder = _NonZeroZeroLogitEmbedder()
+    sc_logits = jnp.ones((2, 4, 5), dtype=jnp.float32)
+    sc_mask = jnp.array([True, False])
+
+    result = hd_gemma_network._encode_self_conditioning(
+        embedder,
+        sc_logits=sc_logits,
+        sc_mask=sc_mask,
+        batch_size=2,
+        canvas_length=4,
+        vocab_size=5,
+        dtype=jnp.float32,
+    )
+
+    np.testing.assert_array_equal(result[0], jnp.ones_like(result[0]))
+    np.testing.assert_array_equal(result[1], jnp.zeros_like(result[1]))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Address the self-conditioning semantics reported in google-deepmind/gemma#773.

Zero vocabulary logits become a nonzero vocabulary-mean embedding after encode_logits, so they cannot represent the report-defined disabled self-conditioning signal. Preserve the existing all-zero-logit sentinel across the embedding boundary and make the no-previous-logits first pass exactly zero as well.

Add regression coverage for the absent signal, the mixed enabled/disabled batch case, and an explicit enable mask.