### PR TITLE
Fix DiffusionGemma selected-canvas SFT decoding

### DIFF
--- a/gemma/diffusion/hackable_diffusion_adapter/hd/sft_model.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/hd/sft_model.py
@@ -87,6 +87,30 @@ class SFTInferenceFn(inference.InferenceFn):
 ################################################################################
 
 
+def _selected_canvas_token_indices(
+    selected_canvas_idx: jnp.ndarray,
+    canvas_size: int,
+) -> jnp.ndarray:
+  """Returns absolute canvas-token indices for each selected canvas."""
+  return (
+      selected_canvas_idx[:, None] * canvas_size
+      + jnp.arange(canvas_size)[None, :]
+  )
+
+
+def _gather_selected_canvas(
+    values: jnp.ndarray,
+    selected_canvas_idx: jnp.ndarray,
+    canvas_size: int,
+) -> jnp.ndarray:
+  """Gathers one contiguous canvas from each batch element."""
+  token_indices = _selected_canvas_token_indices(
+      selected_canvas_idx, canvas_size
+  )
+  batch_indices = jnp.arange(values.shape[0])[:, None]
+  return values[batch_indices, token_indices]
+
+
 def sft_decode(
     gemma_network: Any,
     *,
@@ -103,15 +127,22 @@ def sft_decode(
     sc_logits: jnp.ndarray | None = None,
     is_training: bool = True,
 ) -> hd_typing.TargetInfoTree:
-  """Runs the SFT decoder pass: denoise canvases using the prefilled KV cache.
+  """Runs the SFT decoder pass for only the selected noisy canvas.
 
-  Builds an attention mask where each canvas token attends to the prompt plus
-  all canvases up to and including the selected canvas.
+  The encoder cache contains the prompt and clean response canvases, with its
+  write cursor moved to the start of the selected canvas. Decode only
+  ``canvas_size`` queries so the selected noisy canvas overwrites exactly its
+  own cache slots rather than wrapping into future canvases or the prompt.
+
+  For compatibility with the surrounding loss pipeline, full-response inputs
+  are accepted and the selected logits are scattered back into a full-length
+  tensor before returning. Callers that already pass a selected canvas receive
+  the selected-canvas output directly.
 
   Args:
     gemma_network: The Gemma backbone wrapper (bound or unbound).
-    xt: Noised canvas tokens.
-    time: Diffusion time.
+    xt: Noised selected canvas or full response tokens.
+    time: Diffusion time aligned with ``xt``.
     kv_cache: Prefilled KV cache.
     positions: Full-sequence positions.
     prompt_mask: Non-pad prompt mask.
@@ -126,6 +157,35 @@ def sft_decode(
   Returns:
     Denoiser output dict (e.g., ``{'logits': logits}``).
   """
+  if xt.shape[1] not in (canvas_size, total_canvas_len):
+    raise ValueError(
+        'SFT decoder input length must equal canvas_size or total_canvas_len;'
+        f' got {xt.shape[1]} for canvas_size={canvas_size} and'
+        f' total_canvas_len={total_canvas_len}.'
+    )
+
+  full_response_input = xt.shape[1] == total_canvas_len
+  if full_response_input:
+    selected_xt = _gather_selected_canvas(
+        xt, selected_canvas_idx, canvas_size
+    )
+    if time.ndim >= 2 and time.shape[1] == total_canvas_len:
+      selected_time = _gather_selected_canvas(
+          time, selected_canvas_idx, canvas_size
+      )
+    else:
+      selected_time = time
+    if sc_logits is not None and sc_logits.shape[1] == total_canvas_len:
+      selected_sc_logits = _gather_selected_canvas(
+          sc_logits, selected_canvas_idx, canvas_size
+      )
+    else:
+      selected_sc_logits = sc_logits
+  else:
+    selected_xt = xt
+    selected_time = time
+    selected_sc_logits = sc_logits
+
   attn_mask = mask_helpers.create_decoder_attention_mask(
       prompt_mask=prompt_mask,
       canvas_mask=canvas_mask,
@@ -133,27 +193,49 @@ def sft_decode(
       prompt_len=prompt_len,
       total_canvas_len=total_canvas_len,
       canvas_size=canvas_size,
-      num_queries=total_canvas_len,
+      num_queries=canvas_size,
   )
 
-  # Build canvas positions.
-  canvas_positions = positions[:, prompt_len:]
+  # Select the absolute positions belonging to the active canvas.
+  all_canvas_positions = positions[
+      :, prompt_len : prompt_len + total_canvas_len
+  ]
+  canvas_positions = _gather_selected_canvas(
+      all_canvas_positions, selected_canvas_idx, canvas_size
+  )
 
-  # Build conditioning dict.
   conditioning = {
       'kv_cache': kv_cache,
       'positions': canvas_positions,
       'attention_mask': attn_mask,
   }
-  if sc_logits is not None:
-    conditioning['sc_logits'] = sc_logits
+  if selected_sc_logits is not None:
+    conditioning['sc_logits'] = selected_sc_logits
 
-  return gemma_network(
-      xt=xt,
-      time=time,
+  output = gemma_network(
+      xt=selected_xt,
+      time=selected_time,
       conditioning=conditioning,
       is_training=is_training,
   )
+
+  if not full_response_input:
+    return output
+
+  # The existing loss pipeline operates on full response tensors. Scatter the
+  # selected-canvas predictions back into that layout; non-selected positions
+  # are ignored by target_mask.
+  selected_logits = output['logits']
+  full_logits = jnp.zeros(
+      (selected_logits.shape[0], total_canvas_len) + selected_logits.shape[2:],
+      dtype=selected_logits.dtype,
+  )
+  token_indices = _selected_canvas_token_indices(
+      selected_canvas_idx, canvas_size
+  )
+  batch_indices = jnp.arange(selected_logits.shape[0])[:, None]
+  full_logits = full_logits.at[batch_indices, token_indices].set(selected_logits)
+  return {**output, 'logits': full_logits}
 
 
 def sft_encode(

--- a/gemma/diffusion/hackable_diffusion_adapter/hd/sft_selected_canvas_test.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/hd/sft_selected_canvas_test.py
@@ -1,0 +1,106 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for selected-canvas SFT decoding."""
+
+from absl.testing import absltest
+from gemma.diffusion.hackable_diffusion_adapter.hd import sft_model
+import jax.numpy as jnp
+import numpy as np
+
+
+class SelectedCanvasDecodeTest(absltest.TestCase):
+
+  def _decode(self, xt, time):
+    captured = {}
+
+    def fake_network(*, xt, time, conditioning, is_training):
+      captured['xt'] = xt
+      captured['time'] = time
+      captured['conditioning'] = conditioning
+      captured['is_training'] = is_training
+      return {'logits': xt.astype(jnp.float32)}
+
+    prompt_len = 2
+    total_canvas_len = 6
+    canvas_size = 2
+    positions = jnp.arange(prompt_len + total_canvas_len)[None, :]
+
+    output = sft_model.sft_decode(
+        gemma_network=fake_network,
+        xt=xt,
+        time=time,
+        kv_cache={'sentinel': jnp.array(1)},
+        positions=positions,
+        prompt_mask=jnp.array([[True, True]]),
+        canvas_mask=jnp.ones((1, total_canvas_len), dtype=jnp.bool_),
+        selected_canvas_idx=jnp.array([1], dtype=jnp.int32),
+        prompt_len=prompt_len,
+        total_canvas_len=total_canvas_len,
+        canvas_size=canvas_size,
+        is_training=False,
+    )
+    return output, captured
+
+  def test_full_response_decodes_only_selected_canvas(self):
+    xt = jnp.array([[[10], [11], [20], [21], [30], [31]]])
+    time = jnp.arange(6, dtype=jnp.float32)[None, :, None]
+
+    output, captured = self._decode(xt, time)
+
+    np.testing.assert_array_equal(captured['xt'], xt[:, 2:4])
+    np.testing.assert_array_equal(captured['time'], time[:, 2:4])
+    np.testing.assert_array_equal(
+        captured['conditioning']['positions'], jnp.array([[4, 5]])
+    )
+    self.assertEqual(
+        captured['conditioning']['attention_mask'].shape, (1, 2, 8)
+    )
+    self.assertFalse(captured['is_training'])
+
+    self.assertEqual(output['logits'].shape, (1, 6, 1))
+    np.testing.assert_array_equal(output['logits'][:, 2:4], xt[:, 2:4])
+    np.testing.assert_array_equal(
+        output['logits'][:, :2], jnp.zeros_like(output['logits'][:, :2])
+    )
+    np.testing.assert_array_equal(
+        output['logits'][:, 4:], jnp.zeros_like(output['logits'][:, 4:])
+    )
+
+  def test_future_canvas_does_not_enter_decoder_queries(self):
+    xt = jnp.array([[[10], [11], [20], [21], [30], [31]]])
+    time = jnp.arange(6, dtype=jnp.float32)[None, :, None]
+    changed_future = xt.at[:, 4:].set(99)
+
+    output_a, captured_a = self._decode(xt, time)
+    output_b, captured_b = self._decode(changed_future, time)
+
+    np.testing.assert_array_equal(captured_a['xt'], captured_b['xt'])
+    np.testing.assert_array_equal(
+        output_a['logits'][:, 2:4], output_b['logits'][:, 2:4]
+    )
+
+  def test_preselected_input_is_returned_without_full_length_scatter(self):
+    xt = jnp.array([[[20], [21]]])
+    time = jnp.array([[[2.0], [3.0]]])
+
+    output, captured = self._decode(xt, time)
+
+    np.testing.assert_array_equal(captured['xt'], xt)
+    self.assertEqual(output['logits'].shape, (1, 2, 1))
+    np.testing.assert_array_equal(output['logits'], xt.astype(jnp.float32))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Address the multi-canvas cache semantics reported in google-deepmind/gemma#773.

The SFT encoder moves each cache cursor to the selected canvas start, but the decoder currently submits the full response as queries. For selected canvases after index zero this shifts and wraps K/V writes into later-canvas and prompt slots.

Decode exactly canvas_size queries at the selected canvas positions, gather aligned time and self-conditioning tensors, and scatter the selected logits back only to preserve the existing full-response masked loss interface. Add regression coverage for selected query length, positions, future-canvas isolation, and preselected inputs.