### PR TITLE
Validate tokenizer compatibility in Gemma4Sampler

### DIFF
--- a/gemma/gm/text/_gemma4_sampler.py
+++ b/gemma/gm/text/_gemma4_sampler.py
@@ -95,6 +95,16 @@ class Gemma4Sampler:
           _tokenizer.Tokenizer.from_version(self.model.INFO.tokenizer_version),
       )
 
+    if (
+        self.model.INFO.tokenizer_version
+        and self.tokenizer.VERSION
+        and self.model.INFO.tokenizer_version != self.tokenizer.VERSION
+    ):
+      raise ValueError(
+          'Incompatible model and tokenizer: '
+          f'Got {type(self.model).__name__} and {type(self.tokenizer).__name__}'
+      )
+
   def sample(
       self,
       prompt: str | Sequence[str],

--- a/gemma/gm/text/_gemma4_sampler_test.py
+++ b/gemma/gm/text/_gemma4_sampler_test.py
@@ -1,0 +1,29 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gemma import gm
+import pytest
+
+
+class _Gemma3DummyTokenizer(gm.testing.DummyTokenizer):
+  VERSION = 3
+
+
+def test_rejects_incompatible_tokenizer():
+  with pytest.raises(ValueError, match='Incompatible model and tokenizer'):
+    gm.text.Gemma4Sampler(
+        model=gm.nn.Gemma4_E2B(),
+        params={},
+        tokenizer=_Gemma3DummyTokenizer(),
+    )


### PR DESCRIPTION
## Summary

`Gemma4Sampler` accepted an explicitly supplied tokenizer without checking that its `VERSION` matched `model.INFO.tokenizer_version`. This differs from `Sampler` and can allow incompatible token IDs and special tokens into sampling.

This adds the same compatibility validation already used by `Sampler` and a regression test that verifies a Gemma 4 model rejects a version-3 tokenizer.

## Testing

- Added `gemma/gm/text/_gemma4_sampler_test.py::test_rejects_incompatible_tokenizer`
