### PR TITLE
Preserve explicit zero max_new_tokens in text samplers

### DIFF
--- a/gemma/gm/text/_gemma4_sampler.py
+++ b/gemma/gm/text/_gemma4_sampler.py
@@ -219,12 +219,13 @@ class Gemma4Sampler:
         audio_soft_token_counts=tuple(audio_soft_token_counts),
     )
 
-    if max_new_tokens and max_new_tokens > self.max_out_length:
+    if max_new_tokens is not None and max_new_tokens > self.max_out_length:
       raise ValueError(
           "max_new_tokens should be smaller or equal to max_out_length. Got:"
           f" {max_new_tokens} / {self.max_out_length}"
       )
-    max_new_tokens = max_new_tokens or self.max_out_length
+    if max_new_tokens is None:
+      max_new_tokens = self.max_out_length
     max_new_tokens = jnp.asarray(max_new_tokens)  # pyrefly: ignore[bad-assignment]
 
     sampler = _sampler_loop.SamplerLoop(

--- a/gemma/gm/text/_max_new_tokens_test.py
+++ b/gemma/gm/text/_max_new_tokens_test.py
@@ -43,7 +43,9 @@ def test_sampler_preserves_zero_max_new_tokens():
   sampler_loop = mock.MagicMock()
   sampler_loop.sample.return_value = _fake_state(sampler.max_out_length)
 
-  with mock.patch.object(_sampler._prefill, 'prefill', return_value=mock.MagicMock()):
+  with mock.patch.object(
+      _sampler._prefill, 'prefill', return_value=mock.MagicMock()
+  ):
     with mock.patch.object(
         _sampler.Sampler,
         '_initialize_sampler_loop',

--- a/gemma/gm/text/_max_new_tokens_test.py
+++ b/gemma/gm/text/_max_new_tokens_test.py
@@ -1,0 +1,78 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from gemma import gm
+from gemma.gm.text import _gemma4_sampler
+from gemma.gm.text import _sampler
+import jax.numpy as jnp
+
+
+class _Gemma4DummyTokenizer(gm.testing.DummyTokenizer):
+  VERSION = 4
+
+
+def _fake_state(max_out_length: int):
+  state = mock.MagicMock()
+  state.predicted_tokens = jnp.zeros((1, max_out_length), dtype=jnp.int32)
+  state.cache_info.is_full.item.return_value = False
+  return state
+
+
+def test_sampler_preserves_zero_max_new_tokens():
+  sampler = gm.text.Sampler(
+      model=gm.testing.DummyGemma(),
+      params={},
+      tokenizer=gm.testing.DummyTokenizer(),
+      cache_length=8,
+      max_out_length=4,
+      pad_length=None,
+  )
+  sampler_loop = mock.MagicMock()
+  sampler_loop.sample.return_value = _fake_state(sampler.max_out_length)
+
+  with mock.patch.object(_sampler._prefill, 'prefill', return_value=mock.MagicMock()):
+    with mock.patch.object(
+        _sampler.Sampler,
+        '_initialize_sampler_loop',
+        return_value=sampler_loop,
+    ):
+      sampler.sample('Hello world', max_new_tokens=0)
+
+  assert int(sampler_loop.sample.call_args.kwargs['max_new_tokens']) == 0
+
+
+def test_gemma4_sampler_preserves_zero_max_new_tokens():
+  sampler = gm.text.Gemma4Sampler(
+      model=gm.nn.Gemma4_E2B(),
+      params={},
+      tokenizer=_Gemma4DummyTokenizer(),
+      cache_length=8,
+      max_out_length=4,
+      pad_length=None,
+  )
+  state = _fake_state(sampler.max_out_length)
+
+  with mock.patch.object(
+      _gemma4_sampler._prefill, 'prefill', return_value=mock.MagicMock()
+  ):
+    with mock.patch.object(
+        _gemma4_sampler._sampler_loop.SamplerLoop,
+        'sample',
+        return_value=state,
+    ) as sample_mock:
+      sampler.sample('Hello world', max_new_tokens=0)
+
+  assert int(sample_mock.call_args.kwargs['max_new_tokens']) == 0

--- a/gemma/gm/text/_sampler.py
+++ b/gemma/gm/text/_sampler.py
@@ -332,12 +332,16 @@ class Sampler:
 
     # Max out length is static, while max_new_tokens is dynamic.
     # This allow to change the max out length without recompiling.
-    if max_new_tokens and max_new_tokens > self.max_out_length:
+    if (
+        max_new_tokens is not None
+        and max_new_tokens > self.max_out_length
+    ):
       raise ValueError(
           'max_new_tokens should be smaller or equal to max_out_length. Got:'
           f' {max_new_tokens} / {self.max_out_length}'
       )
-    max_new_tokens = max_new_tokens or self.max_out_length
+    if max_new_tokens is None:
+      max_new_tokens = self.max_out_length
     max_new_tokens = jnp.asarray(max_new_tokens)
 
     # TODO(epot): Donate the `init_state`, `last_state`


### PR DESCRIPTION
## Summary

`Sampler.sample()` and `Gemma4Sampler.sample()` currently use truthiness when normalizing `max_new_tokens`. As a result, an explicit `max_new_tokens=0` is treated the same as `None` and replaced with `max_out_length`, so callers requesting zero decoding steps can unexpectedly generate a full response.

This changes the normalization to use `None` as the only sentinel for the default. An explicit `0` is preserved and passed to the sampling loop, which already supports zero decoding steps.

`ChatSampler` benefits automatically because it forwards `max_new_tokens` unchanged to the underlying sampler.

## Testing

- Added regression coverage for `Sampler` with `max_new_tokens=0`.
- Added regression coverage for `Gemma4Sampler` with `max_new_tokens=0`.
- Fork CI workflow triggered on the final branch commit.
