### PR TITLE
Validate top-k sampling bounds

### DIFF
--- a/gemma/gm/text/_sampling.py
+++ b/gemma/gm/text/_sampling.py
@@ -70,6 +70,13 @@ class TopkSampling(SamplingMethod):
 
   @typechecked
   def get_next_tokens(self, logits: Float['*B V'], rng: PRNGKey) -> Int['*B']:  # pyrefly: ignore[not-a-type]
+    vocab_size = logits.shape[-1]
+    if not 1 <= self.k <= vocab_size:
+      raise ValueError(
+          f'`k` must be between 1 and the vocabulary size ({vocab_size}). Got:'
+          f' {self.k}'
+      )
+
     logits, batch_shape = enp.flatten(logits, '... V')
 
     batch_size = logits.shape[0]

--- a/gemma/gm/text/_sampling_test.py
+++ b/gemma/gm/text/_sampling_test.py
@@ -15,6 +15,7 @@
 from gemma import gm
 import jax.numpy
 import numpy as np
+import pytest
 
 
 def test_greedy_sampling():
@@ -45,6 +46,16 @@ def test_topk_sampling():
   logits = jax.random.normal(rng, shape=(batch_size, vocab_size))
   tokens = sampling.get_next_tokens(logits, rng)
   assert tokens.shape == (batch_size,)
+
+
+@pytest.mark.parametrize('k', [0, -1, 6])
+def test_topk_sampling_rejects_invalid_k(k):
+  sampling = gm.text.TopkSampling(k=k)
+  rng = jax.random.PRNGKey(0)
+  logits = jax.random.normal(rng, shape=(2, 5))
+
+  with pytest.raises(ValueError, match='`k` must be between 1'):
+    sampling.get_next_tokens(logits, rng)
 
 
 def test_topp_sampling():


### PR DESCRIPTION
## Summary

`TopkSampling.get_next_tokens()` currently passes `k` directly to JAX. Invalid values fail with low-level errors: `k=0` produces an empty candidate set and categorical sampling fails, while negative values and values larger than the vocabulary fail inside `jax.lax.top_k`.

This validates `k` against the available vocabulary size before calling JAX and raises a clear `ValueError` for invalid values.

## Testing

- Added parametrized coverage for `k=0`, `k=-1`, and `k` larger than the vocabulary size.
- Existing top-k and top-1/greedy sampling tests remain unchanged.
