### PR TITLE
Validate top-p sampling bounds

### DIFF
--- a/gemma/gm/text/_sampling.py
+++ b/gemma/gm/text/_sampling.py
@@ -91,6 +91,9 @@ class TopPSampling(SamplingMethod):
 
   @typechecked
   def get_next_tokens(self, logits: Float['... V'], rng: PRNGKey) -> Int['...']:  # pyrefly: ignore[bad-index, not-a-type]
+    if not 0.0 <= self.p <= 1.0:
+      raise ValueError(f'`p` must be between 0 and 1. Got: {self.p}')
+
     # temperature scaling
     logits = logits / self.temperature
 

--- a/gemma/gm/text/_sampling_test.py
+++ b/gemma/gm/text/_sampling_test.py
@@ -15,6 +15,7 @@
 from gemma import gm
 import jax.numpy
 import numpy as np
+import pytest
 
 
 def test_greedy_sampling():
@@ -55,6 +56,16 @@ def test_topp_sampling():
   logits = jax.random.normal(rng, shape=(batch_size, vocab_size))
   tokens = sampling.get_next_tokens(logits, rng)
   assert tokens.shape == (batch_size,)
+
+
+@pytest.mark.parametrize('p', [-0.1, 1.1])
+def test_topp_sampling_rejects_invalid_p(p):
+  sampling = gm.text.TopPSampling(p=p)
+  rng = jax.random.PRNGKey(0)
+  logits = jax.random.normal(rng, shape=(2, 5))
+
+  with pytest.raises(ValueError, match='`p` must be between 0 and 1'):
+    sampling.get_next_tokens(logits, rng)
 
 
 def test_topp_sampling_with_skewed_logits():


### PR DESCRIPTION
## Summary

`TopPSampling.get_next_tokens()` currently accepts `p` values outside the probability range. Values below 0 collapse the cutoff to the highest-logit token, while values above 1 skip nucleus filtering entirely, so invalid configuration silently changes sampling behaviour.

This validates `p` before sampling and raises a clear `ValueError` unless it is within `[0, 1]`. Boundary values remain supported: `p=0` keeps the current top-1 behaviour and `p=1` keeps unrestricted sampling.

## Testing

- Added parametrized regression coverage for `p=-0.1` and `p=1.1`.
- Existing top-p tests remain unchanged.
