### PR TITLE
Validate LoRA einsum weight shape

### DIFF
--- a/gemma/peft/_einsum_utils.py
+++ b/gemma/peft/_einsum_utils.py
@@ -44,6 +44,12 @@ def get_lora_einsum_str_and_shapes(
   # e.g. split `'BTNH,NHD->BTD'` into `('BTNH', 'NHD', 'BTD')`.
   inputs, weights, outputs = _split_einsum_str(einsum_str)
 
+  if len(weights_shape) != len(weights):
+    raise ValueError(
+        '`weights_shape` should match the weight dimensions in `einsum_str`. '
+        f'Got shape {tuple(weights_shape)} for weight operand {weights!r}.'
+    )
+
   # Extract the inputs dimensions which will be reduced and the outputs
   # dimensions.
   # Example: BTNH,NHD->BTD

--- a/gemma/peft/_einsum_utils_test.py
+++ b/gemma/peft/_einsum_utils_test.py
@@ -61,3 +61,13 @@ def test_einsum():
         weights_shape=(3, 4),
         rank=2,
     )
+
+
+@pytest.mark.parametrize('weights_shape', [(3,), (3, 4, 5)])
+def test_einsum_rejects_weights_shape_mismatch(weights_shape):
+  with pytest.raises(ValueError, match='`weights_shape` should match'):
+    _einsum_utils.get_lora_einsum_str_and_shapes(
+        einsum_str='...ij,jk->...ik',
+        weights_shape=weights_shape,
+        rank=2,
+    )


### PR DESCRIPTION
## Summary

`get_lora_einsum_str_and_shapes()` maps the einsum weight operand to `weights_shape` using `zip()`. When the shape has too few dimensions, the missing dimension later surfaces as a `KeyError`. When it has too many dimensions, `zip()` silently discards the extras.

This adds an explicit dimensionality check before constructing the LoRA shapes, so invalid configurations fail early with a clear `ValueError`.

## Testing

- Added regression coverage for a `weights_shape` with too few dimensions.
- Added regression coverage for a `weights_shape` with too many dimensions.
