### PR TITLE
Centralize Gemma 4 sliding attention masking

### DIFF
--- a/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku_full.py
+++ b/gemma/diffusion/hackable_diffusion_adapter/configs/sft_sudoku_full.py
@@ -34,7 +34,7 @@ _orig_call = _orig_block.__call__
 @functools.partial(
     nn.remat,
     policy=jax.checkpoint_policies.nothing_saveable,
-    static_argnums=7,
+    static_argnums=8,
 )
 def rematted_call_fn(
     self,
@@ -44,7 +44,8 @@ def rematted_call_fn(
     attn_mask,
     per_layer_input,
     kv_shared_cache,
-    skip_sliding_mask,
+    sliding_attention_mask,
+    disable_sliding_window,
 ):
   return _orig_call(
       self,
@@ -54,7 +55,8 @@ def rematted_call_fn(
       attn_mask,
       per_layer_input=per_layer_input,
       kv_shared_cache=kv_shared_cache,
-      skip_sliding_mask=skip_sliding_mask,
+      sliding_attention_mask=sliding_attention_mask,
+      disable_sliding_window=disable_sliding_window,
   )
 
 def new_call(
@@ -65,7 +67,8 @@ def new_call(
     attn_mask,
     per_layer_input=None,
     kv_shared_cache=None,
-    skip_sliding_mask=False,
+    sliding_attention_mask=None,
+    disable_sliding_window=False,
 ):
   return rematted_call_fn(
       self,
@@ -75,7 +78,8 @@ def new_call(
       attn_mask,
       per_layer_input,
       kv_shared_cache,
-      skip_sliding_mask,
+      sliding_attention_mask,
+      disable_sliding_window,
   )
 
 _modules.Block.__call__ = new_call

--- a/gemma/gm/nn/gemma4/_modules.py
+++ b/gemma/gm/nn/gemma4/_modules.py
@@ -246,7 +246,8 @@ class Attention(nn.Module):
       cache: LayerCache | None,
       attn_mask: jax.Array,
       kv_shared_cache: LayerCache | None = None,
-      skip_sliding_mask: bool = False,
+      sliding_attention_mask: jax.Array | None = None,
+      disable_sliding_window: bool = False,
   ) -> tuple[LayerCache | None, jax.Array]:
     """Applies multi-head attention to the inputs.
 
@@ -256,7 +257,8 @@ class Attention(nn.Module):
       cache: KV cache or None.
       attn_mask: Attention mask of shape [batch_size, seq_len, cache_size].
       kv_shared_cache: Cache for shared KV layers.
-      skip_sliding_mask: If True, skip the sliding mask.
+      sliding_attention_mask: Optional base mask for local sliding attention.
+      disable_sliding_window: Whether to skip automatic sliding-window masking.
 
     Returns:
       cache: Updated attention KV cache.
@@ -337,18 +339,21 @@ class Attention(nn.Module):
       logits = jnp.tanh(logits / self.attn_logits_soft_cap)
       logits = logits * self.attn_logits_soft_cap
 
-    if self.attn_type == AttentionType.LOCAL_SLIDING and not skip_sliding_mask:
-      if self.sliding_window_size is None:
-        raise ValueError(
-            'Sliding_window_size must be set if Local Sliding attention type'
+    if self.attn_type == AttentionType.LOCAL_SLIDING:
+      if sliding_attention_mask is not None:
+        attn_mask = sliding_attention_mask
+      if not disable_sliding_window:
+        if self.sliding_window_size is None:
+          raise ValueError(
+              'Sliding_window_size must be set if Local Sliding attention type'
+          )
+        sliding_mask = _create_sliding_mask(
+            segment_pos,
+            cache_positions=cache_positions,
+            sliding_window_size=self.sliding_window_size,
         )
-      sliding_mask = _create_sliding_mask(
-          segment_pos,
-          cache_positions=cache_positions,
-          sliding_window_size=self.sliding_window_size,
-      )
-      # [batch_size, seq_len, cache_size]
-      attn_mask *= sliding_mask
+        # [batch_size, seq_len, cache_size]
+        attn_mask *= sliding_mask
 
     # [batch_size, seq_len, num_heads, cache_size]
     padded_logits = jnp.where((jnp.expand_dims(attn_mask, -2)), logits, K_MASK)
@@ -598,7 +603,8 @@ class Block(nn.Module):
       attn_mask: jax.Array,
       per_layer_input: jax.Array | None = None,
       kv_shared_cache: LayerCache | None = None,
-      skip_sliding_mask: bool = False,
+      sliding_attention_mask: jax.Array | None = None,
+      disable_sliding_window: bool = False,
   ) -> tuple[LayerCache | None, jax.Array]:
     """Applies the block to the inputs.
 
@@ -610,7 +616,8 @@ class Block(nn.Module):
       per_layer_input: Per-layer input of shape [batch_size, seq_len,
         per_layer_input_dim].
       kv_shared_cache: Cache for shared KV layers.
-      skip_sliding_mask: If True, skip the sliding mask.
+      sliding_attention_mask: Optional base mask for local sliding attention.
+      disable_sliding_window: Whether to skip automatic sliding-window masking.
 
     Returns:
       cache: Updated attention KV cache.
@@ -625,7 +632,8 @@ class Block(nn.Module):
         cache,
         attn_mask,
         kv_shared_cache,
-        skip_sliding_mask=skip_sliding_mask,
+        sliding_attention_mask=sliding_attention_mask,
+        disable_sliding_window=disable_sliding_window,
     )
 
     if self.post_attention_norm is not None:

--- a/gemma/gm/nn/gemma4/_modules_test.py
+++ b/gemma/gm/nn/gemma4/_modules_test.py
@@ -1,0 +1,150 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Gemma 4 transformer modules."""
+
+from gemma.gm.nn.gemma4 import _modules
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _capture_attention_probs(
+    attn_type: _modules.AttentionType,
+    *,
+    disable_sliding_window: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+  seq_len = 4
+  sliding_window_size = 2
+
+  attention = _modules.Attention(
+      num_heads=1,
+      num_kv_heads=1,
+      features=4,
+      key_size=2,
+      attn_type=attn_type,
+      sliding_window_size=sliding_window_size,
+      qk_norm_with_scale=False,
+      rope_proportion=1.0,
+  )
+
+  x = jnp.arange(
+      1,
+      seq_len * 4 + 1,
+      dtype=jnp.float32,
+  ).reshape(1, seq_len, 4)
+
+  positions = jnp.arange(
+      seq_len,
+      dtype=jnp.int32,
+  )[None, :]
+
+  attention_mask = jnp.ones(
+      (1, seq_len, seq_len),
+      dtype=jnp.bool_,
+  )
+
+  # Each row includes a token outside the local window so that applying
+  # the sliding-window mask produces a result different from this base mask.
+  sliding_attention_mask = jnp.array(
+      [[
+          [1, 0, 0, 1],
+          [0, 1, 0, 1],
+          [1, 0, 1, 0],
+          [1, 0, 0, 1],
+      ]],
+      dtype=jnp.bool_,
+  )
+
+  variables = attention.init(
+      jax.random.key(0),
+      x,
+      positions,
+      None,
+      attention_mask,
+      sliding_attention_mask=sliding_attention_mask,
+      disable_sliding_window=disable_sliding_window,
+  )
+
+  (_, _), state = attention.apply(
+      variables,
+      x,
+      positions,
+      None,
+      attention_mask,
+      sliding_attention_mask=sliding_attention_mask,
+      disable_sliding_window=disable_sliding_window,
+      capture_intermediates=True,
+      mutable=['intermediates'],
+  )
+
+  probs = state['intermediates']['attention_weights']['__call__'][0]
+
+  if attn_type == _modules.AttentionType.LOCAL_SLIDING:
+    expected_mask = sliding_attention_mask
+
+    if not disable_sliding_window:
+      window_mask = _modules._create_sliding_mask(
+          positions,
+          sliding_window_size=sliding_window_size,
+      )
+      expected_mask = sliding_attention_mask & window_mask
+  else:
+    expected_mask = attention_mask
+
+  return np.asarray(probs), np.asarray(expected_mask)
+
+
+@pytest.mark.parametrize(
+    'attn_type',
+    [
+        _modules.AttentionType.GLOBAL,
+        _modules.AttentionType.LOCAL_SLIDING,
+    ],
+)
+def test_attention_owns_mask_selection(
+    attn_type: _modules.AttentionType,
+):
+  probs, expected_mask = _capture_attention_probs(attn_type)
+
+  # Masked logits receive K_MASK and therefore have zero probability.
+  observed_mask = probs[:, :, 0, :] > 0.0
+
+  np.testing.assert_array_equal(
+      observed_mask,
+      expected_mask,
+  )
+
+
+def test_attention_can_disable_sliding_window():
+  _, normal_mask = _capture_attention_probs(
+      _modules.AttentionType.LOCAL_SLIDING,
+  )
+
+  probs, disabled_mask = _capture_attention_probs(
+      _modules.AttentionType.LOCAL_SLIDING,
+      disable_sliding_window=True,
+  )
+
+  observed_mask = probs[:, :, 0, :] > 0.0
+
+  # The fixture must distinguish S from S & W, otherwise this test could pass
+  # without proving that the window was actually disabled.
+  assert not np.array_equal(normal_mask, disabled_mask)
+
+  np.testing.assert_array_equal(
+      observed_mask,
+      disabled_mask,
+  )

--- a/gemma/gm/nn/gemma4/_transformer.py
+++ b/gemma/gm/nn/gemma4/_transformer.py
@@ -364,25 +364,17 @@ class Transformer(nn.Module):
         kv_shared_cache = new_cache.get(shared_layer_name)
       else:
         kv_shared_cache = None
-      # Select the appropriate attention mask for this layer type.
-      attn_mask = inputs.attention_mask
-      skip_sliding_mask = False
-      if (
-          inputs.sliding_attention_mask is not None
-          and block.attn_type == _modules.AttentionType.LOCAL_SLIDING
-      ):
-        attn_mask = inputs.sliding_attention_mask
-        skip_sliding_mask = False
       layer_cache, x = block(
           x,
           inputs.positions,
           old_cache.get(layer_name),
-          attn_mask,
+          inputs.attention_mask,
           per_layer_inputs[..., i, :]  # pyrefly: ignore[unsupported-operation]
           if self.config.per_layer_input_dim
           else None,
           kv_shared_cache=kv_shared_cache,
-          skip_sliding_mask=skip_sliding_mask,
+          sliding_attention_mask=inputs.sliding_attention_mask,
+          disable_sliding_window=False,
       )
       new_cache[layer_name] = layer_cache  # pytype: disable=container-type-mismatch
 


### PR DESCRIPTION
## Summary

- centralize Gemma 4 sliding-attention mask selection and composition in `Attention`
- pass the raw `attention_mask` and `sliding_attention_mask` through `Transformer`
- replace `skip_sliding_mask` with the clearer `disable_sliding_window` intent flag
- update the diffusion remat wrapper so the sliding mask remains dynamic while the disable flag remains static
- add regression coverage for global/local mask ownership and disabling the sliding window

## Details

Previously, `Transformer` selected between `attention_mask` and
`sliding_attention_mask` before calling the block, while `_modules.py` also
controlled application of the sliding-window mask. This split responsibility
for the final effective mask across multiple modules.

This change moves that responsibility into `Attention`:

- global attention continues to use `attention_mask`
- local sliding attention uses `sliding_attention_mask` when provided
- the automatic sliding-window mask is composed in `Attention`
- `disable_sliding_window=True` skips only the automatic window constraint

`Transformer` now forwards the raw masks without making an attention-type
decision.

The diffusion gradient-checkpointing wrapper is also updated for the new
arguments. `sliding_attention_mask` remains a dynamic JAX argument, while
`disable_sliding_window` is treated as the static boolean argument.

## Testing

- `python -m pytest gemma/gm/nn/gemma4 -q`
  - 14 passed
- changed Python files compile successfully with `py_compile`
- verified the old `skip_sliding_mask` API is no longer referenced
- executed the remat wrapper with both `disable_sliding_window=False` and
  `disable_sliding_window=True`
- `git diff --check` passes

Fixes #662