### PR TITLE
Fix _print_stream crash when the stream is empty

### DIFF
--- a/gemma/gm/text/_chat_sampler.py
+++ b/gemma/gm/text/_chat_sampler.py
@@ -466,8 +466,10 @@ def _print_stream(
 ) -> _sampler.SamplerOutput:
   """Prints the streaming output."""
   text_tokens = []
+  last_state = None
 
   for state in out:
+    last_state = state
     print_(stream, state.text)  # pyrefly: ignore[bad-argument-type]
 
     text_tokens.append(state.text)
@@ -475,7 +477,14 @@ def _print_stream(
         state.text == '<end_of_turn>' or state.text == '<turn|>'
     ):  # Last token is not printed.
       continue
-  out = dataclasses.replace(state, text=''.join(text_tokens))  # pylint: disable=undefined-variable,undefined-loop-variable  # pyrefly: ignore[bad-assignment]
+
+  if last_state is None:
+    raise ValueError(
+        'Streaming sampling produced no tokens. This can happen when'
+        ' `max_new_tokens` is 0 or when the cache is full before any token'
+        ' could be generated (try increasing `cache_length`).'
+    )
+  out = dataclasses.replace(last_state, text=''.join(text_tokens))  # pyrefly: ignore[bad-assignment]
   return out  # pyrefly: ignore[bad-return]
 
 


### PR DESCRIPTION
ChatSampler 开 print_stream 时，如果模型一个 token 都没生成（max_new_tokens=0，或者 cache_length 太小一上来就满了），`_print_stream` 会在循环结束后去用没绑定的循环变量 `state`，直接抛 UnboundLocalError，用户根本看不出是哪的问题。

改成在循环里记下最后一个 state，流是空的话抛一条明确的 ValueError，提示大概率是 max_new_tokens=0 或 cache 满了（建议加大 cache_length）。非空流的行为完全不变。

顺带把之前压着这个问题的 `# pylint: disable=undefined-variable,undefined-loop-variable` 去掉了，因为现在这个 bug 真正被处理了。