### PR TITLE
Add Gemma 2 tokenizer conformance vectors

### DIFF
--- a/docs/tokenizer.md
+++ b/docs/tokenizer.md
@@ -1,1 +1,25 @@
 # Tokenizer
+
+## Conformance vectors
+
+The repository includes a small, versioned set of Gemma 2 tokenizer conformance
+vectors in `gemma/conformance/v1/gemma2_tokenizer.json`. The fixture records the
+published tokenizer model source and SHA-256, plus exact token IDs for ASCII,
+Unicode, whitespace, and BOS/EOS boundary cases.
+
+Run the vectors against the reference implementation with:
+
+```bash
+python -m gemma.conformance
+```
+
+To validate a local copy of the tokenizer model instead of the published GCS
+path:
+
+```bash
+python -m gemma.conformance --tokenizer-path /path/to/tokenizer.model
+```
+
+The JSON fixture is intended to be portable so downstream implementations can
+run the same cases without depending on the Gemma Python package. Token IDs are
+exact comparisons; decoded text is compared exactly as UTF-8 text.

--- a/gemma/conformance/__init__.py
+++ b/gemma/conformance/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reference conformance fixtures for Gemma implementations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_FIXTURE = Path(__file__).with_name('v1') / 'gemma2_tokenizer.json'
+
+
+def load_fixture(path: str | Path | None = None) -> dict[str, Any]:
+  """Loads a versioned conformance fixture."""
+  fixture_path = Path(path) if path is not None else _DEFAULT_FIXTURE
+  return json.loads(fixture_path.read_text(encoding='utf-8'))
+
+
+def check_tokenizer(tokenizer: Any, fixture: dict[str, Any]) -> list[str]:
+  """Returns mismatch descriptions for a tokenizer fixture."""
+  mismatches = []
+  for case in fixture['cases']:
+    actual_ids = tokenizer.encode(
+        case['text'],
+        add_bos=case.get('add_bos', False),
+        add_eos=case.get('add_eos', False),
+    )
+    if actual_ids != case['token_ids']:
+      mismatches.append(
+          f"{case['name']}: token ids {actual_ids} != {case['token_ids']}"
+      )
+      continue
+
+    expected_text = case.get('decoded_text')
+    if expected_text is not None:
+      actual_text = tokenizer.decode(case['token_ids'])
+      if actual_text != expected_text:
+        mismatches.append(
+            f"{case['name']}: decoded text {actual_text!r} != {expected_text!r}"
+        )
+  return mismatches

--- a/gemma/conformance/__main__.py
+++ b/gemma/conformance/__main__.py
@@ -1,0 +1,59 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command-line runner for Gemma conformance fixtures."""
+
+from __future__ import annotations
+
+import argparse
+
+from gemma import conformance
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+      '--fixture', help='Path to a tokenizer fixture JSON file.'
+  )
+  parser.add_argument(
+      '--tokenizer-path',
+      help=(
+          'Tokenizer model path. Defaults to the source recorded in the'
+          ' fixture.'
+      ),
+  )
+  args = parser.parse_args()
+
+  fixture = conformance.load_fixture(args.fixture)
+  if fixture['kind'] != 'tokenizer' or fixture['tokenizer']['version'] != 2:
+    parser.error(
+        'This runner currently supports Gemma 2 tokenizer fixtures only.'
+    )
+
+  from gemma import gm  # Imported lazily to keep fixture inspection lightweight.
+
+  tokenizer_path = args.tokenizer_path or fixture['tokenizer']['source']
+  tokenizer = gm.text.Gemma2Tokenizer(path=tokenizer_path)
+  mismatches = conformance.check_tokenizer(tokenizer, fixture)
+  if mismatches:
+    for mismatch in mismatches:
+      print(f'FAIL: {mismatch}')
+    return 1
+
+  print(f"PASS: {len(fixture['cases'])} tokenizer conformance cases")
+  return 0
+
+
+if __name__ == '__main__':
+  raise SystemExit(main())

--- a/gemma/conformance/conformance_test.py
+++ b/gemma/conformance/conformance_test.py
@@ -1,0 +1,68 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gemma import conformance
+
+
+class _FakeTokenizer:
+
+  def encode(self, text, *, add_bos=False, add_eos=False):
+    ids = [len(text)]
+    if add_bos:
+      ids.insert(0, 2)
+    if add_eos:
+      ids.append(1)
+    return ids
+
+  def decode(self, ids):
+    del ids
+    return 'decoded'
+
+
+def test_check_tokenizer_passes_matching_case():
+  fixture = {
+      'cases': [{
+          'name': 'example',
+          'text': 'abc',
+          'add_bos': True,
+          'add_eos': True,
+          'token_ids': [2, 3, 1],
+          'decoded_text': 'decoded',
+      }]
+  }
+
+  assert not conformance.check_tokenizer(_FakeTokenizer(), fixture)
+
+
+def test_check_tokenizer_reports_token_id_mismatch():
+  fixture = {
+      'cases': [{
+          'name': 'example',
+          'text': 'abc',
+          'token_ids': [99],
+      }]
+  }
+
+  mismatches = conformance.check_tokenizer(_FakeTokenizer(), fixture)
+
+  assert mismatches == ['example: token ids [3] != [99]']
+
+
+def test_default_fixture_is_versioned_gemma2_tokenizer():
+  fixture = conformance.load_fixture()
+
+  assert fixture['schema_version'] == 1
+  assert fixture['kind'] == 'tokenizer'
+  assert fixture['tokenizer']['version'] == 2
+  assert fixture['cases']

--- a/gemma/conformance/v1/gemma2_tokenizer.json
+++ b/gemma/conformance/v1/gemma2_tokenizer.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "kind": "tokenizer",
+  "tokenizer": {
+    "version": 2,
+    "source": "gs://gemma-data/tokenizers/tokenizer_gemma2.model",
+    "sha256": "61a7b147390c64585d6c3543dd6fc636906c9af3865a5548f27f31aee1d4c8e2"
+  },
+  "cases": [
+    {
+      "name": "ascii",
+      "text": "Hello world!",
+      "token_ids": [4521, 2134, 235341],
+      "decoded_text": "Hello world!"
+    },
+    {
+      "name": "ascii_with_boundaries",
+      "text": "Hello world!",
+      "add_bos": true,
+      "add_eos": true,
+      "token_ids": [2, 4521, 2134, 235341, 1],
+      "decoded_text": "Hello world!"
+    },
+    {
+      "name": "unicode_latin",
+      "text": "café",
+      "token_ids": [81453],
+      "decoded_text": "café"
+    },
+    {
+      "name": "newline",
+      "text": "line one\nline two",
+      "token_ids": [703, 974, 108, 703, 1378],
+      "decoded_text": "line one\nline two"
+    },
+    {
+      "name": "math_spacing",
+      "text": "2 + 2 = 4",
+      "token_ids": [235284, 963, 235248, 235284, 589, 235248, 235310],
+      "decoded_text": "2 + 2 = 4"
+    },
+    {
+      "name": "unicode_cjk",
+      "text": "こんにちは世界",
+      "token_ids": [32789, 9979],
+      "decoded_text": "こんにちは世界"
+    }
+  ]
+}


### PR DESCRIPTION
Addresses #786.

## Summary

- add a versioned Gemma 2 tokenizer conformance fixture with six deterministic ASCII, Unicode, whitespace, and BOS/EOS cases
- bind the fixture to the published tokenizer model using its source path and SHA-256
- add `python -m gemma.conformance` to verify the vectors against the reference tokenizer, with an override for a local tokenizer model
- document the fixture and add offline tests for the conformance checker

This is intentionally the first narrow slice of the broader conformance proposal. It does not add checkpoint or logits fixtures yet.

## Validation

- `pytest -q gemma/conformance/conformance_test.py`: 3 passed
- all 6 fixture cases reproduced against the published Gemma 2 tokenizer model
- fixture SHA-256 matched the downloaded published tokenizer model
- built the wheel and verified `gemma/conformance/v1/gemma2_tokenizer.json` is included
- `pyink --fast --check gemma/conformance`
- `git diff --check`
